### PR TITLE
netif: dpvs exits if NIC bound to numa node -1

### DIFF
--- a/src/netif.c
+++ b/src/netif.c
@@ -2595,6 +2595,8 @@ static struct netif_port* netif_port_alloc(portid_t id, int nrxq,
     port->nrxq = nrxq; // port_rx_queues_get();
     port->ntxq = ntxq; // port_tx_queues_get();
     port->socket = rte_eth_dev_socket_id(id);
+    if (port->socket == SOCKET_ID_ANY)
+        port->socket = rte_socket_id();
     port->mbuf_pool = pktmbuf_pool[port->socket]; 
     rte_eth_macaddr_get(id, &port->addr);
     rte_eth_dev_get_mtu(id, &port->mtu);


### PR DESCRIPTION
on same arch, NIC bound to numa node -1:

```bash
cat /sys/bus/pci/devices/0000\:01\:00.1/numa_node
-1
```
and `dpvs` exit exceptionally

```bash
EAL: Error - exiting with code: 1
  Cause: add KNI port fail, exiting...
```