### PR TITLE
dpvs: add switch to make it possible to capture forwarding packets in dpvs node

### DIFF
--- a/include/conf/netif.h
+++ b/include/conf/netif.h
@@ -234,6 +234,8 @@ typedef struct netif_nic_set {
     uint16_t promisc_off:1;
     uint16_t link_status_up:1;
     uint16_t link_status_down:1;
+    uint16_t forward2kni_on:1;
+    uint16_t forward2kni_off:1;
 } netif_nic_set_t;
 
 typedef struct netif_nic_mbufpool {

--- a/include/mbuf.h
+++ b/include/mbuf.h
@@ -111,4 +111,12 @@ static inline void *mbuf_header_pointer(const struct rte_mbuf *mbuf,
  */
 int mbuf_may_pull(struct rte_mbuf *mbuf, unsigned int len);
 
+/**
+* Copy a rte_mbuf including the data area.
+*
+* return a new rte_mbuf if success and NULL on error.
+*/
+struct rte_mbuf *mbuf_copy(struct rte_mbuf *md, struct rte_mempool *mp);
+void mbuf_copy_metadata(struct rte_mbuf *mi, struct rte_mbuf *m);
+
 #endif /* __DP_VS_MBUF_H__ */

--- a/include/netif.h
+++ b/include/netif.h
@@ -33,6 +33,7 @@
 #define NETIF_PORT_FLAG_TX_UDP_CSUM_OFFLOAD 0x1<<6
 #define NETIF_PORT_FLAG_TX_VLAN_INSERT_OFFLOAD  0x1<<7
 #define NETIF_PORT_FLAG_RX_VLAN_STRIP_OFFLOAD   0x1<<8
+#define NETIF_PORT_FLAG_FORWARD2KNI   0x1<<9
 
 /* max tx/rx queue number for each nic */
 #define NETIF_MAX_QUEUES            16
@@ -234,7 +235,7 @@ struct netif_port {
     char                    name[DEVICE_NAME_MAX_LEN];  /* device name */
     portid_t                id;                         /* device id */
     port_type_t             type;                       /* device type */
-    uint8_t                 flag;                       /* device flag */
+    uint16_t                flag;                       /* device flag */
     int                     nrxq;                       /* rx queue number */
     int                     ntxq;                       /* tx queue numbe */
     uint16_t                rxq_desc_nb;                /* rx queue descriptor number */

--- a/src/ip_vs_core.c
+++ b/src/ip_vs_core.c
@@ -737,7 +737,7 @@ int dp_vs_init(void)
 
     err = dp_vs_synproxy_init();
     if (err != EDPVS_OK) {
-        RTE_LOG(ERR, IPVS, "fail to init conn: %s\n", dpvs_strerror(err));
+        RTE_LOG(ERR, IPVS, "fail to init synproxy: %s\n", dpvs_strerror(err));
         goto err_synproxy;
     }
 

--- a/src/netif.c
+++ b/src/netif.c
@@ -1789,10 +1789,27 @@ static inline void netif_tx_burst(lcoreid_t cid, portid_t pid, queueid_t qindex)
 {
     int ntx, ii;
     struct netif_queue_conf *txq;
+    unsigned i = 0;
+    struct rte_mbuf *mbuf_cloned = NULL;
+    struct netif_port *dev = NULL;
+
     assert(LCORE_ID_ANY != cid);
     txq = &lcore_conf[lcore2index[cid]].pqs[port2index[cid][pid]].txqs[qindex];
     if (0 == txq->len)
         return;
+
+    dev = netif_port_get(pid);
+    if (dev && (dev->flag & NETIF_PORT_FLAG_FORWARD2KNI)) {
+        for (; i<txq->len; i++) {
+            /*The rte_mbuf pending to transmit won't be modified any more. So, rte_pktmbuf_clone is ok. */
+            if (NULL == (mbuf_cloned = rte_pktmbuf_clone(txq->mbufs[i], pktmbuf_pool[dev->socket])))
+                RTE_LOG(WARNING, NETIF, "%s: Failed to clone mbuf\n", __func__);
+            else
+                kni_ingress(mbuf_cloned, dev, txq);
+        }
+        kni_send2kern_loop(pid, txq);
+    }
+
     ntx = rte_eth_tx_burst(pid, txq->id, txq->mbufs, txq->len);
     lcore_stats[cid].opackets += ntx;
     /* do not calculate obytes here in consideration of efficency */
@@ -2000,7 +2017,8 @@ static inline int netif_deliver_mbuf(struct rte_mbuf *mbuf,
     assert(dev != NULL);
 
     pt = pkt_type_get(eth_type, dev);
-    if (NULL == pt) {
+
+    if (!(dev->flag & NETIF_PORT_FLAG_FORWARD2KNI) && NULL == pt) {
         kni_ingress(mbuf, dev, qconf);
         return EDPVS_OK;
     }
@@ -2028,6 +2046,7 @@ static void lcore_job_recv_fwd(void *arg)
     lcoreid_t cid;
     struct netif_queue_conf *qconf;
     struct ether_hdr *eth_hdr;
+    struct rte_mbuf *mbuf_copied = NULL;
 
     cid = rte_lcore_id();
     assert(LCORE_ID_ANY != cid);
@@ -2069,6 +2088,20 @@ static void lcore_job_recv_fwd(void *arg)
                 eth_hdr = rte_pktmbuf_mtod(mbuf, struct ether_hdr *);
                 /* reuse mbuf.packet_type, it was RTE_PTYPE_XXX */
                 mbuf->packet_type = eth_type_parse(eth_hdr, dev);
+
+                /*
+                   * In NETIF_PORT_FLAG_FORWARD2KNI mode.
+                   * All packets received are deep copied and sent to  KNI  for the purpose of capturing forwarding packets.
+                   * Since the rte_mbuf will be modified in the following procedure, we should use
+                   * mbuf_copy instead of rte_pktmbuf_clone.
+                   */
+                if (dev->flag & NETIF_PORT_FLAG_FORWARD2KNI) {
+                    if (likely(NULL != (mbuf_copied = mbuf_copy(mbuf, pktmbuf_pool[dev->socket]))))
+                        kni_ingress(mbuf_copied, dev, qconf);
+                    else
+                        RTE_LOG(WARNING, NETIF, "%s: Failed to copy mbuf\n", __func__);
+                }
+
                 /*
                  * do not drop pkt to other hosts (ETH_PKT_OTHERHOST)
                  * since virtual devices may have different MAC with
@@ -4284,6 +4317,14 @@ static int set_port(struct netif_port *port, const netif_nic_set_t *port_cfg)
             RTE_LOG(INFO, NETIF, "[%s] promiscuous mode for %s disabled\n",
                     __func__, port_cfg->pname);
         }
+    }
+
+    if (port_cfg->forward2kni_on) {
+        port->flag |= NETIF_PORT_FLAG_FORWARD2KNI;
+        RTE_LOG(INFO, NETIF, "[%s] forward2kni mode for %s enabled\n", __func__, port_cfg->pname);
+    } else if (port_cfg->forward2kni_off) {
+        port->flag &= ~(NETIF_PORT_FLAG_FORWARD2KNI);
+        RTE_LOG(INFO, NETIF, "[%s] forward2kni mode for %s disabled\n", __func__, port_cfg->pname);
     }
 
     if (port_cfg->link_status_up) {

--- a/tools/dpip/link.c
+++ b/tools/dpip/link.c
@@ -130,7 +130,7 @@ static void link_help(void)
             "    dpip -s link show [ i INTERVAL ] [ c COUNT ]  CPU-NAME\n"
             "    dpip link set DEV-NAME ITEM VALUE\n"
             "    ---supported items---\n"
-            "    promisc [on|off], link [up|down], addr, \n"
+            "    promisc [on|off], forward2kni [on|off], link [up|down], addr, \n"
             "    bond-[mode|slave|primary|ximit-policy|monitor-interval|link-up-prop|"
             "link-down-prop]\n"
             "Examples:\n"
@@ -141,6 +141,7 @@ static void link_help(void)
             "    dpip -s -v link show cpu3 i 2\n"
             "    dpip link show bond0 status\n"
             "    dpip link set dpdk0 promisc on/off\n"
+            "    dpip link set dpdk0 forward2kni on/off\n"
             "    dpip link set bond0 link up/down\n"
            );
 }
@@ -870,6 +871,25 @@ static int link_nic_set_promisc(const char *name, const char *value)
     return dpvs_setsockopt(SOCKOPT_NETIF_SET_PORT, &cfg, sizeof(netif_nic_set_t));
 }
 
+static int link_nic_set_forward2kni(const char *name, const char *value)
+{
+    assert(value);
+
+    netif_nic_set_t cfg;
+    memset(&cfg, 0, sizeof(cfg));
+    strncpy(cfg.pname, name, sizeof(cfg.pname) - 1);
+    if (strcmp(value, "on") == 0)
+        cfg.forward2kni_on = 1;
+    else if(strcmp(value, "off") == 0)
+        cfg.forward2kni_off = 1;
+    else {
+        fprintf(stderr, "invalid arguement value for 'forward2kni'\n");
+        return EDPVS_INVAL;
+    }
+
+    return dpvs_setsockopt(SOCKOPT_NETIF_SET_PORT, &cfg, sizeof(netif_nic_set_t));
+}
+
 static int link_nic_set_link_status(const char *name, const char *value)
 {
     assert(value);
@@ -1168,6 +1188,8 @@ static int link_set(struct link_param *param)
 
             if (strcmp(param->item, "promisc") == 0)
                 link_nic_set_promisc(param->dev_name, param->value);
+            else if (strcmp(param->item, "forward2kni") == 0)
+                link_nic_set_forward2kni(param->dev_name, param->value);
             else if (strcmp(param->item, "link") == 0)
                 link_nic_set_link_status(param->dev_name, param->value);
             else if (strcmp(param->item, "addr") == 0)


### PR DESCRIPTION
add forward2kni switch to make it possible to capture forwarding packets in dpvs node via KNI device. It's helpful for debugging.