### PR TITLE
netif: packet capturing support by kni for debug.

### DIFF
--- a/include/conf/netif.h
+++ b/include/conf/netif.h
@@ -38,6 +38,7 @@ typedef uint16_t queueid_t;
 #define NETIF_PORT_FLAG_TX_IP_CSUM_OFFLOAD  0x1<<4
 #define NETIF_PORT_FLAG_TX_TCP_CSUM_OFFLOAD 0x1<<5
 #define NETIF_PORT_FLAG_TX_UDP_CSUM_OFFLOAD 0x1<<6
+#define NETIF_PORT_FLAG_FORWARD2KNI   0x1<<9
 
 #define ETH_LINK_DOWN           0
 #define ETH_LINK_UP             1
@@ -124,7 +125,7 @@ typedef struct netif_nic_basic_get
 {
     portid_t port_id;
     char name[32];
-    uint8_t flags; /* NETIF_PORT_FLAG_ */
+    uint16_t flags; /* NETIF_PORT_FLAG_ */
     uint8_t nrxq;
     uint8_t ntxq;
     char addr[32];
@@ -234,6 +235,8 @@ typedef struct netif_nic_set {
     uint16_t promisc_off:1;
     uint16_t link_status_up:1;
     uint16_t link_status_down:1;
+    uint16_t forward2kni_on:1;
+    uint16_t forward2kni_off:1;
 } netif_nic_set_t;
 
 typedef struct netif_nic_mbufpool {

--- a/include/mbuf.h
+++ b/include/mbuf.h
@@ -111,4 +111,12 @@ static inline void *mbuf_header_pointer(const struct rte_mbuf *mbuf,
  */
 int mbuf_may_pull(struct rte_mbuf *mbuf, unsigned int len);
 
+/**
+* Copy a rte_mbuf including the data area.
+*
+* return a new rte_mbuf if success and NULL on error.
+*/
+struct rte_mbuf *mbuf_copy(struct rte_mbuf *md, struct rte_mempool *mp);
+void mbuf_copy_metadata(struct rte_mbuf *mi, struct rte_mbuf *m);
+
 #endif /* __DP_VS_MBUF_H__ */

--- a/include/netif.h
+++ b/include/netif.h
@@ -33,6 +33,7 @@
 #define NETIF_PORT_FLAG_TX_UDP_CSUM_OFFLOAD 0x1<<6
 #define NETIF_PORT_FLAG_TX_VLAN_INSERT_OFFLOAD  0x1<<7
 #define NETIF_PORT_FLAG_RX_VLAN_STRIP_OFFLOAD   0x1<<8
+#define NETIF_PORT_FLAG_FORWARD2KNI   0x1<<9
 
 /* max tx/rx queue number for each nic */
 #define NETIF_MAX_QUEUES            16
@@ -234,7 +235,7 @@ struct netif_port {
     char                    name[DEVICE_NAME_MAX_LEN];  /* device name */
     portid_t                id;                         /* device id */
     port_type_t             type;                       /* device type */
-    uint8_t                 flag;                       /* device flag */
+    uint16_t                flag;                       /* device flag */
     int                     nrxq;                       /* rx queue number */
     int                     ntxq;                       /* tx queue numbe */
     uint16_t                rxq_desc_nb;                /* rx queue descriptor number */

--- a/src/ip_vs_core.c
+++ b/src/ip_vs_core.c
@@ -737,7 +737,7 @@ int dp_vs_init(void)
 
     err = dp_vs_synproxy_init();
     if (err != EDPVS_OK) {
-        RTE_LOG(ERR, IPVS, "fail to init conn: %s\n", dpvs_strerror(err));
+        RTE_LOG(ERR, IPVS, "fail to init synproxy: %s\n", dpvs_strerror(err));
         goto err_synproxy;
     }
 


### PR DESCRIPTION
Add flag to enable/disable packet capturing through kni device.
When enabled, all packets TX/RX will be copied and passed to KNI.
It's for debug only, and will affect the performance significantly.