### PR TITLE
conf: fix invalid configuration 'netif_defs/device/tx/descriptor_number'

### DIFF
--- a/conf/dpvs.conf.items
+++ b/conf/dpvs.conf.items
@@ -25,12 +25,12 @@ netif_defs {
         rx {
             #max_burst_size     32
             queue_number        6           <16, 0-16>
-            descriptor_number   128         <64, 16-8192>
+            descriptor_number   256         <256, 16-8192>
             rss                 ip          <tcp, tcp|ip>
         }
         tx {
             queue_number        6           <16, 0-16>
-            descriptor_number   256         <128, 16-8192>
+            descriptor_number   512         <512, 16-8192>
         }
     !    promisc_mode                       <disable>
     !    kni_name               dpdk0.kni   <char[32]>

--- a/src/netif.c
+++ b/src/netif.c
@@ -46,11 +46,11 @@ static int netif_pktpool_nb_mbuf = NETIF_PKTPOOL_NB_MBUF_DEF;
 #define NETIF_PKTPOOL_MBUF_CACHE_MAX    8192
 static int netif_pktpool_mbuf_cache = NETIF_PKTPOOL_MBUF_CACHE_DEF;
 
-#define NETIF_NB_RX_DESC_DEF    64
+#define NETIF_NB_RX_DESC_DEF    256
 #define NETIF_NB_RX_DESC_MIN    16
 #define NETIF_NB_RX_DESC_MAX    8192
 
-#define NETIF_NB_TX_DESC_DEF    128
+#define NETIF_NB_TX_DESC_DEF    512
 #define NETIF_NB_TX_DESC_MIN    16
 #define NETIF_NB_TX_DESC_MAX    8192
 
@@ -324,13 +324,11 @@ static void tx_desc_nb_handler(vector_t tokens)
         RTE_LOG(WARNING, NETIF, "invalid nb_tx_desc %s, using default %d\n",
                 str, NETIF_NB_TX_DESC_DEF);
         current_device->tx_desc_nb = NETIF_NB_TX_DESC_DEF;
-        //netif_nb_tx_desc = NETIF_NB_TX_DESC_DEF;
     } else {
         is_power2(desc_nb, 0, &desc_nb);
         RTE_LOG(INFO, NETIF, "%s:nb_tx_desc = %d (round to 2^n)\n",
                 current_device->name, desc_nb);
-        current_device->tx_desc_nb = NETIF_NB_TX_DESC_DEF;
-        //netif_nb_tx_desc = desc_nb;
+        current_device->tx_desc_nb = desc_nb;
     }
 
     FREE_PTR(str);


### PR DESCRIPTION
default value of netif_defs/device/tx/descriptor_number changed from 64->256
default value of netif_defs/device/tx/descriptor_number changed from 128->512

note that both rx and tx descriptor_number  are set to 1024 in /etc/dpvs.conf*.sample