### PR TITLE
keepalived: fix crash when 'virtual_routes' configured without src

### DIFF
--- a/tools/keepalived/keepalived/vrrp/vrrp_ipaddress.c
+++ b/tools/keepalived/keepalived/vrrp/vrrp_ipaddress.c
@@ -96,6 +96,9 @@ ipaddresstos(ip_address_t *ipaddress)
 {
 	char *addr_str = (char *) MALLOC(INET6_ADDRSTRLEN);
 
+    if (!ipaddress)
+        return addr_str;
+
 	if (IP_IS6(ipaddress)) {
 		inet_ntop(AF_INET6, &ipaddress->u.sin6_addr, addr_str, INET6_ADDRSTRLEN);
 	} else {


### PR DESCRIPTION
keepalived.conf

```bash
 39     virtual_routes {
 40         10.0.1.0/24 via 192.168.1.1 dev dpdk0
 41     }
```

core dump

```bash
#0  ipaddresstos (ipaddress=0x0) at vrrp_ipaddress.c:98
98	vrrp_ipaddress.c: No such file or directory.
(gdb) bt
#0  ipaddresstos (ipaddress=0x0) at vrrp_ipaddress.c:98
#1  0x0000000000412548 in netlink_route (iproute=0x1ae6760, cmd=1) at vrrp_iproute.c:72
#2  0x0000000000412634 in netlink_rtlist (rt_list=0x1ad90a0, cmd=0, cmd@entry=1) at vrrp_iproute.c:100
#3  0x0000000000413694 in vrrp_handle_iproutes (cmd=cmd@entry=1, vrrp=0x1ad8d50, vrrp=0x1ad8d50) at vrrp.c:69
#4  0x0000000000413f75 in vrrp_state_become_master (vrrp=vrrp@entry=0x1ad8d50) at vrrp.c:766
#5  0x0000000000414443 in vrrp_state_master_tx (vrrp=vrrp@entry=0x1ad8d50, prio=prio@entry=0) at vrrp.c:923
#6  0x0000000000415827 in vrrp_master (vrrp=0x1ad8d50) at vrrp_scheduler.c:789
#7  0x0000000000416051 in vrrp_dispatcher_read_to (fd=<optimized out>) at vrrp_scheduler.c:853
#8  vrrp_read_dispatcher_thread (thread=0x7fff2e472a10) at vrrp_scheduler.c:939
#9  0x00000000004263bd in thread_call (thread=0x7fff2e472a10) at scheduler.c:759
#10 launch_scheduler () at scheduler.c:782
#11 0x000000000041235b in start_vrrp_child () at vrrp_daemon.c:338
#12 0x0000000000403128 in start_keepalived () at main.c:85
#13 main (argc=<optimized out>, argv=<optimized out>) at main.c:303
```
