### PR TITLE
Add todo list and fix build where pushd not support.

### DIFF
--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -1,0 +1,24 @@
+DPVS TODO list
+==============
+
+Short-term
+----------
+
+* merge DPDK-17.05.2 [done, release soon]
+* basic traffic control [done, release soon]
+* neighbour (ARP) refactor [done, release soon]
+* Tunnel Interface (gre/ipip) [on-going]
+* NAT/Tunnel forwarding mode [on-going]
+* performance optimization.
+* documents update.
+
+Long-term
+---------
+
+* packet sampling
+* consistent hashing
+* ALG (ftp, sip, ...)
+* VxLAN Support
+* NIC without Flow-Director (fdir)
+  - packet redirect for cpus
+* IPv6 Support

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -27,9 +27,9 @@ config: keepalived_conf
 
 keepalived_conf:
 	if [ ! -f keepalived/Makefile ]; then \
-		pushd keepalived && \
+		cd keepalived && \
 		./configure && \
-		popd; \
+		cd -; \
 	fi
 
 clean:


### PR DESCRIPTION
1. on some env, `pushd` is not supported, so use `cd -` to get back.
2. add todo list for short-term and long-term plan.