### PR TITLE
Add status of icmp session for ipvsadm -lc optimize the unkown status info of tcp/udp sessions.

### DIFF
--- a/include/ipvs/proto_icmp.h
+++ b/include/ipvs/proto_icmp.h
@@ -1,0 +1,24 @@
+/*
+ * DPVS is a software load balancer (Virtual Server) based on DPDK.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+
+#ifndef __DP_VS_PROTO_ICMP_H__
+#define __DP_VS_PROTO_ICMP_H__
+
+enum {
+    DPVS_ICMP_S_NORMAL      = 0,
+    DPVS_ICMP_S_LAST
+};
+
+#endif

--- a/src/ipvs/ip_vs_conn.c
+++ b/src/ipvs/ip_vs_conn.c
@@ -29,6 +29,7 @@
 #include "ipvs/synproxy.h"
 #include "ipvs/proto_tcp.h"
 #include "ipvs/proto_udp.h"
+#include "ipvs/proto_icmp.h"
 #include "parser/parser.h"
 #include "ctrl.h"
 #include "conf/conn.h"
@@ -953,7 +954,7 @@ static inline char* get_conn_state_name(uint16_t proto, uint16_t state)
                     return "SYNACK";
                     break;
                 default:
-                    return "UNKOWN";
+                    return "TCP_UNKOWN";
                     break;
             }
             break;
@@ -966,7 +967,20 @@ static inline char* get_conn_state_name(uint16_t proto, uint16_t state)
                     return "UDP_LAST";
                     break;
                 default:
-                    return "UNKOWN";
+                    return "UDP_UNKOWN";
+                    break;
+            }
+            break;
+        case IPPROTO_ICMP:
+            switch (state) {
+                case DPVS_ICMP_S_NORMAL:
+                    return "ICMP_NORMAL";
+                    break;
+                case DPVS_ICMP_S_LAST:
+                    return "ICMP_LAST";
+                    break;
+                default:
+                    return "ICMP_UNKOWN";
                     break;
             }
             break;

--- a/src/ipvs/ip_vs_proto_icmp.c
+++ b/src/ipvs/ip_vs_proto_icmp.c
@@ -28,6 +28,7 @@
 #include "ipv4.h"
 #include "ipvs/ipvs.h"
 #include "ipvs/proto.h"
+#include "ipvs/proto_icmp.h"
 #include "ipvs/conn.h"
 #include "ipvs/service.h"
 
@@ -59,11 +60,6 @@
  *   + For ICMP-Error, which includes original IP packet as payload:
  *     Those embedded IPs are not be handled here IPVS core.
  */
-
-enum {
-    DPVS_ICMP_S_NORMAL      = 0,
-    DPVS_ICMP_S_LAST
-};
 
 static int icmp_timeouts[DPVS_ICMP_S_LAST + 1] = {
     [DPVS_ICMP_S_NORMAL]    = 300,


### PR DESCRIPTION
Add status of icmp session for ipvsadm -lc optimize the unkown status info of tcp/udp sessions.