### PR TITLE
Add a switch of ipv4_forward in ipv4_defs config section.

### DIFF
--- a/conf/dpvs.conf.sample
+++ b/conf/dpvs.conf.sample
@@ -219,6 +219,7 @@ neigh_defs {
 
 ! dpvs ipv4 config
 ipv4_defs {
+    <init> ipv4_forward off ! set this to on, dpvs will forward packets that NOT hit rules directly
     <init> default_ttl         64
     fragment {
         <init> bucket_number   4096


### PR DESCRIPTION
Set it to off, and dpvs won't forward packets that don't match the rules.