### PR TITLE
Fix crash for service, msg timeout and ARP issues.

### DIFF
--- a/include/ipvs/dest.h
+++ b/include/ipvs/dest.h
@@ -75,6 +75,8 @@ struct dp_vs_dest {
     uint32_t            vfwmark;    /* firewall mark of service */
     struct dp_vs_service *svc;      /* service it belongs to */
     union inet_addr     vaddr;      /* virtual IP address */
+    unsigned            conn_timeout; /* conn timeout copied from svc*/
+    unsigned            limit_proportion; /* limit copied from svc*/ 
 } __rte_cache_aligned;
 
 struct dp_vs_dest_conf {

--- a/src/ipvs/ip_vs_dest.c
+++ b/src/ipvs/ip_vs_dest.c
@@ -137,6 +137,9 @@ struct dp_vs_dest *dp_vs_trash_get_dest(struct dp_vs_service *svc,
             (svc->fwmark ||
              (inet_addr_equal(svc->af, &dest->vaddr, &svc->addr) &&
               dest->vport == svc->port))) {
+             /*since svc may be edit, variables should be coverd*/
+             dest->conn_timeout = svc->conn_timeout;
+             dest->limit_proportion = svc->limit_proportion;
              return dest;
             }
         if (rte_atomic32_read(&dest->refcnt) == 1) {
@@ -223,6 +226,8 @@ int dp_vs_new_dest(struct dp_vs_service *svc, struct dp_vs_dest_conf *udest,
     dest->proto = svc->proto;
     dest->vaddr = svc->addr;
     dest->vport = svc->port;
+    dest->conn_timeout = svc->conn_timeout;
+    dest->limit_proportion = svc->limit_proportion;
     dest->vfwmark = svc->fwmark;
     dest->addr = udest->addr;
     dest->port = udest->port;

--- a/src/ipvs/ip_vs_dest.c
+++ b/src/ipvs/ip_vs_dest.c
@@ -428,7 +428,7 @@ void __dp_vs_del_dest(struct dp_vs_dest *dest)
            and only one user context can update virtual service at a
            time, so the operation here is OK */
         rte_atomic32_dec(&dest->svc->refcnt);
-
+        dest->svc = NULL;
         dp_vs_del_stats(dest->stats);
         rte_free(dest);
     } else {

--- a/src/ipvs/ip_vs_service.c
+++ b/src/ipvs/ip_vs_service.c
@@ -664,10 +664,8 @@ out:
 unsigned dp_vs_get_conn_timeout(struct dp_vs_conn *conn)
 {
     unsigned conn_timeout;
-    if (conn->dest->svc) {
-        rte_atomic32_inc(&(conn->dest->svc->usecnt));
-        conn_timeout = conn->dest->svc->conn_timeout;
-        rte_atomic32_dec(&(conn->dest->svc->usecnt));
+    if (conn->dest) {
+        conn_timeout = conn->dest->conn_timeout;
         return conn_timeout;
     }
     return 90;

--- a/src/ipvs/ip_vs_stats.c
+++ b/src/ipvs/ip_vs_stats.c
@@ -207,17 +207,14 @@ int dp_vs_stats_in(struct dp_vs_conn *conn, struct rte_mbuf *mbuf)
 
     if (dest && (dest->flags & DPVS_DEST_F_AVAILABLE)) {
         /*limit rate*/
-        assert(dest->svc);
-        if ((dest->svc->limit_proportion < 100) &&
-            (dest->svc->limit_proportion > 0)) {
-            return (rand()%100) > dest->svc->limit_proportion 
+        if ((dest->limit_proportion < 100) &&
+            (dest->limit_proportion > 0)) {
+            return (rand()%100) > dest->limit_proportion 
                         ? EDPVS_OVERLOAD : EDPVS_OK;
         }
 
         dest->stats[cid].inpkts++;
         dest->stats[cid].inbytes += mbuf->pkt_len;
-        dest->svc->stats[cid].inpkts++;  
-        dest->svc->stats[cid].inbytes += mbuf->pkt_len;
     }
 
     this_dpvs_stats.inpkts++;
@@ -234,17 +231,14 @@ int dp_vs_stats_out(struct dp_vs_conn *conn, struct rte_mbuf *mbuf)
 
     if (dest && (dest->flags & DPVS_DEST_F_AVAILABLE)) {
         /*limit rate*/
-        assert(dest->svc);
-        if ((dest->svc->limit_proportion < 100) && 
-            (dest->svc->limit_proportion > 0)) {
-            return (rand()%100) > dest->svc->limit_proportion 
+        if ((dest->limit_proportion < 100) && 
+            (dest->limit_proportion > 0)) {
+            return (rand()%100) > dest->limit_proportion 
 			? EDPVS_OVERLOAD : EDPVS_OK; 
         }
 
         dest->stats[cid].outpkts++;
         dest->stats[cid].outbytes += mbuf->pkt_len;
-        dest->svc->stats[cid].outpkts++;
-        dest->svc->stats[cid].outbytes += mbuf->pkt_len;
     }
 
     this_dpvs_stats.outpkts++;
@@ -254,12 +248,11 @@ int dp_vs_stats_out(struct dp_vs_conn *conn, struct rte_mbuf *mbuf)
 
 void dp_vs_stats_conn(struct dp_vs_conn *conn)
 {
-    assert(conn && conn->dest && conn->dest->svc);
+    assert(conn && conn->dest);
     lcoreid_t cid;
 
     cid = rte_lcore_id();   
     conn->dest->stats[cid].conns++;
-    conn->dest->svc->stats[cid].conns++;
     this_dpvs_stats.conns++;
 }
 

--- a/tools/ipvsadm/ipvsadm.c
+++ b/tools/ipvsadm/ipvsadm.c
@@ -1644,6 +1644,19 @@ static inline char *fwd_switch(unsigned flags)
 	return swt;
 }
 
+/*notice when rs is deleted svc stats count will be less than before*/
+static void copy_stats_from_dest(ipvs_service_entry_t *se, struct ip_vs_get_dests *d)
+{
+	int i = 0;
+	for (i = 0; i < d->num_dests; i++) {
+		ipvs_dest_entry_t *e = &d->entrytable[i];
+		se->stats.conns += e->stats.conns;
+		se->stats.inpkts += e->stats.inpkts;
+		se->stats.outpkts += e->stats.outpkts;
+		se->stats.inbytes += e->stats.inbytes;
+		se->stats.outbytes += e->stats.outbytes;
+	}
+}
 
 static void print_largenum(unsigned long long i, unsigned int format)
 {
@@ -1787,6 +1800,9 @@ print_service_entry(ipvs_service_entry_t *se, unsigned int format)
                                  ",oif=%s", se->oifname);
         }
     }
+
+	/* copy svc's stats from dest */
+	copy_stats_from_dest(se, d);
 
 	/* print virtual service info */
 	if (format & FMT_RULE) {

--- a/tools/keepalived/keepalived/vrrp/vrrp_ipaddress.c
+++ b/tools/keepalived/keepalived/vrrp/vrrp_ipaddress.c
@@ -33,11 +33,11 @@
 
 static void dpvs_fill_addrconf(ip_address_t *ipaddress, char *dpdk_port, struct inet_addr_param *param)
 {
-    memset(param, 0, sizeof(*param));
     param->af = ipaddress->ifa.ifa_family;
     param->addr.in = ipaddress->u.sin.sin_addr;
     strcpy(param->ifname, dpdk_port);
     param->plen = ipaddress->ifa.ifa_prefixlen;
+    param->flags &= ~IFA_F_SAPOOL;
 }
 
 static int
@@ -48,9 +48,9 @@ netlink_ipaddress(ip_address_t *ipaddress, char *dpdk_port, int cmd)
     tmp_ip = ipaddresstos(ipaddress);
     if (dpdk_port == NULL)//ingore static route or sth. othes
         return 1;
+    memset(&param, 0, sizeof(param));
     dpvs_fill_addrconf(ipaddress, dpdk_port, &param);
     ipvs_set_ipaddr(&param, cmd);
-    log_message(LOG_INFO, "add vip %s to dpdk port %s", tmp_ip, dpdk_port);
     FREE(tmp_ip);
     return 1;
 }


### PR DESCRIPTION
1. fix assert and crash when `dest->svc` is NULL.
2. fix bug for choosing source ip for ARP request.
3. workaround: msg timeout problem when printing all session entries.