### PR TITLE
netif: intergating with DPDK-17.05.2 in forward2kni mode and inet: bugfix

### DIFF
--- a/src/inet.c
+++ b/src/inet.c
@@ -128,7 +128,7 @@ bool inet_addr_same_net(int af, uint8_t plen,
 
     switch (af) {
     case AF_INET:
-        mask = ~((0x1<<(32-plen)) - 1);
+        mask = htonl(~((0x1<<(32-plen)) - 1));
         return !((addr1->in.s_addr^addr2->in.s_addr)&mask);
     default:
         return false;

--- a/tools/dpip/link.c
+++ b/tools/dpip/link.c
@@ -1253,6 +1253,10 @@ static int link_set(struct link_param *param)
                 link_nic_set_tc_egress(param->dev_name, param->value);
             else if (strcmp(param->item, "tc-ingress") == 0)
                 link_nic_set_tc_ingress(param->dev_name, param->value);
+            else {
+                fprintf(stderr, "invalid parameter name '%s'\n", param->item);
+                return EDPVS_INVAL;
+            }
             break;
         }
         case LINK_DEVICE_CPU:


### PR DESCRIPTION
1. replace rte_pktmbuf_clone with mbuf_copy in netif_tx_burst since
rte_kni_tx_burst is changed in DPDK-17.05.2;
2. free the mbuf while kni_ingress is unnecessary due to forward2kni
flag is enable;
3. add error message for dpip link command;