### PR TITLE
Don't load ip_vs kernel module and fix a segmentation fault.

### DIFF
--- a/tools/keepalived/keepalived/check/check_data.c
+++ b/tools/keepalived/keepalived/check/check_data.c
@@ -42,6 +42,9 @@ alloc_ssl(void)
 void
 free_ssl(void)
 {
+	if (!check_data)
+		return;
+
 	ssl_data_t *ssl = check_data->ssl;
 
 	if (!ssl)
@@ -55,6 +58,9 @@ free_ssl(void)
 static void
 dump_ssl(void)
 {
+	if (!check_data)
+      return;
+
 	ssl_data_t *ssl = check_data->ssl;
 
 	if (ssl->password)
@@ -507,6 +513,8 @@ alloc_check_data(void)
 void
 free_check_data(check_data_t *data)
 {
+	if (!check_data)
+		return;
 	free_list(data->vs);
 	free_list(data->vs_group);
 	free_list(data->laddr_group);

--- a/tools/keepalived/keepalived/check/ipwrapper.c
+++ b/tools/keepalived/keepalived/check/ipwrapper.c
@@ -136,6 +136,9 @@ clear_service_vs(list vs_group, virtual_server_t * vs)
 int
 clear_services(void)
 {
+	if (!check_data)
+		return 0;
+
 	element e;
 	list l = check_data->vs;
 	virtual_server_t *vs;

--- a/tools/keepalived/keepalived/core/global_data.c
+++ b/tools/keepalived/keepalived/core/global_data.c
@@ -147,6 +147,8 @@ init_global_data(data_t * data)
 void
 free_global_data(data_t * data)
 {
+	if (!data)
+		return;
 	free_list(data->email);
 	FREE_PTR(data->router_id);
 	FREE_PTR(data->plugin_dir);


### PR DESCRIPTION
1. Don't load kernel module in keepalived for dpvs.
2. Fix segmentation fault on starting keepalived without dpvs.
Thank you.