### PR TITLE
dpip/link: use port name instead of ID.

### DIFF
--- a/tools/dpip/link.c
+++ b/tools/dpip/link.c
@@ -83,38 +83,32 @@ struct link_param
 }; 
 
 bool g_color = false;
-netif_nic_num_get_t g_nports;
+netif_nic_list_get_t *g_nic_list = NULL;
 
-static inline int get_netif_port_nb(void)
+static inline int get_netif_port_list(void)
 {
     int ret;
     size_t len;
-    netif_nic_num_get_t *p_nports = NULL;
+    netif_nic_list_get_t *p_port_list = NULL;
 
-    ret = dpvs_getsockopt(SOCKOPT_NETIF_GET_PORT_NUM, NULL, 0,
-            (void **)&p_nports, &len);
-    if (EDPVS_OK != ret || !p_nports || !len) {
-        fprintf(stderr, "Fail to get configured NIC number: %s.\n",
+    ret = dpvs_getsockopt(SOCKOPT_NETIF_GET_PORT_LIST, NULL, 0,
+            (void **)&p_port_list, &len);
+    if (EDPVS_OK != ret || !p_port_list || !len) {
+        fprintf(stderr, "Fail to get configured NIC list: %s.\n",
                 dpvs_strerror(ret));
         return ret;
     }
-    g_nports = *p_nports;
-    dpvs_sockopt_msg_free((void *)p_nports);
+    if (g_nic_list)
+        free(g_nic_list);
+    g_nic_list = calloc(1, len);
+    if (!g_nic_list)
+        return EDPVS_NOMEM;
+
+    memcpy(g_nic_list, p_port_list, len);
+
+    dpvs_sockopt_msg_free((void *)p_port_list);
 
     return EDPVS_OK;
-}
-
-static inline int get_pid_by_name(const char *name)
-{
-    int pid;
-    for (pid = 0; pid < g_nports.nic_num; pid++) {
-        //printf("port[%d/%d]=%s\n", pid, g_nports.nic_num, g_nports.pid_name_map[pid]);
-        if (pid >= NETIF_MAX_PORTS)
-            break;
-        if (!strcmp(g_nports.pid_name_map[pid], name))
-            return pid;
-    }
-    return -1;
 }
 
 static void link_help(void)
@@ -149,38 +143,22 @@ static void link_help(void)
            );
 }
 
-/* check device name, return 0 and fill its id if OK, otherwise return -1 */
-static inline int link_check_dev_name(link_device_t type, const char *name, unsigned *id)
+/* check cpu name, return 0 and fill its id if OK, otherwise return -1 */
+static inline int link_get_cpu_id(const char *name, unsigned *id)
 {
     char *endptr;
-    assert(name && id);
+    assert(id != NULL);
 
-    switch(type) {
-        case LINK_DEVICE_NIC:
-        {
-            int res;
-            res = get_pid_by_name(name);
-            if (res < 0)
-                return -1;
-            *id = res;
-            return 0;
-        }
-        case LINK_DEVICE_CPU:
-        {
-            if (strncmp(name, "cpu", 3))
-                return -1;
-            if (strlen(name) == 3)
-                return 0;
-            else {
-                *id = strtol(&name[3], &endptr, 10);
-                if (*endptr)
-                    return -1;
-            }
-            return 0;
-        }
-        default:
-            return -1;
-    }
+    if (strncmp(name, "cpu", 3))
+        return -1;
+    if (strlen(name) == 3)
+        return 0;
+
+    *id = strtol(&name[3],&endptr, 10);
+    if (*endptr)
+        return -1;
+
+    return 0;
 }
 
 static int link_parse_args(struct dpip_conf *conf,
@@ -193,21 +171,25 @@ static int link_parse_args(struct dpip_conf *conf,
     param->stats.count = conf->count;
     param->dev_type = LINK_DEVICE_NIC; /* default show NIC */
 
-    while (conf->argc > 0) {
-        if (!strncmp(conf->argv[0], "dpdk", 4) ||
-                !strncmp(conf->argv[0], "eth", 3)) {
-            snprintf(param->dev_name, sizeof(param->dev_name), "%s", conf->argv[0]);
-        } else if (!strncmp(conf->argv[0], "bond", 4) &&
-                strncmp(conf->argv[0], "bond-", 5)) {
-            snprintf(param->dev_name, sizeof(param->dev_name), "%s", conf->argv[0]);
-            if (conf->argc > 1 && !strncmp(conf->argv[1], "status", 6)) {
-                param->status = 1;
-                NEXTARG(conf);
-            }
-        } else if (strncmp(conf->argv[0], "cpu", 3) == 0) {
+    /* parse device name */
+    if (conf->argc > 0) {
+        if (strncmp(conf->argv[0], "cpu", 3) == 0) {
             param->dev_type = LINK_DEVICE_CPU;
             if (strcmp(conf->argv[0], "cpu") != 0)
                 snprintf(param->dev_name, sizeof(param->dev_name), "%s", conf->argv[0]);
+        } else {
+            param->dev_type = LINK_DEVICE_NIC;
+            snprintf(param->dev_name, sizeof(param->dev_name), "%s", conf->argv[0]);
+        }
+        NEXTARG(conf);
+    }
+
+    /* parse other params */
+    while (conf->argc > 0) {
+        if (conf->cmd == DPIP_CMD_SHOW) {
+            if (!strncmp(conf->argv[0], "status", 6)) {
+                param->status = 1;
+            }
         } else if (conf->cmd == DPIP_CMD_SET ||
                 conf->cmd == DPIP_CMD_ADD ||
                 conf->cmd == DPIP_CMD_DEL) {
@@ -233,56 +215,38 @@ static int link_parse_args(struct dpip_conf *conf,
     return EDPVS_OK;
 }
 
-static int dump_nic_basic(portid_t pid)
+static int dump_nic_basic(char *name, int namelen)
 {
     int err;
     size_t len = 0;
     netif_nic_basic_get_t get, *p_get = NULL;
 
-    err = dpvs_getsockopt(SOCKOPT_NETIF_GET_PORT_BASIC, &pid, sizeof(pid), (void **)&p_get, &len);
+    err = dpvs_getsockopt(SOCKOPT_NETIF_GET_PORT_BASIC, name, namelen,
+            (void **)&p_get, &len);
     if (err != EDPVS_OK || !p_get || !len)
         return err;
     get = *p_get; 
     dpvs_sockopt_msg_free(p_get);
 
-    assert(pid == get.port_id);
     printf("%d: %s: socket %d mtu %d rx-queue %d tx-queue %d\n",
             get.port_id + 1, get.name, get.socket_id, get.mtu, get.nrxq, get.ntxq);
 
     printf("    ");
-    switch (get.link_status) {
-        case ETH_LINK_UP:
-            printf("UP ");
-            break;
-        case ETH_LINK_DOWN:
-            printf("DOWN ");
-            break;
-    }
+    if (get.link_status[0])
+        printf("%s ", get.link_status);
 
     printf("%d Mbps ", get.link_speed);
 
-    switch (get.link_duplex) {
-        case ETH_LINK_HALF_DUPLEX:
-            printf("half-duplex ");
-            break;
-        case ETH_LINK_FULL_DUPLEX:
-            printf("full-duplex ");
-            break;
-    }
+    if (get.link_duplex[0])
+        printf("%s ", get.link_duplex);
 
-    switch (get.link_autoneg) {
-        case ETH_LINK_FIXED:
-            printf("fixed-nego ");
-            break;
-        case ETH_LINK_AUTONEG:
-            printf("auto-nego ");
-            break;
-    }
+    if (get.link_autoneg[0])
+        printf("%s ", get.link_autoneg);
 
     if (get.promisc)
         printf("promisc ");
 
-    if (get.flags & NETIF_PORT_FLAG_FORWARD2KNI)
+    if (get.fwd2kni)
         printf("foward2kni ");
 
     if (get.tc_egress)
@@ -307,13 +271,14 @@ static int dump_nic_basic(portid_t pid)
     return EDPVS_OK;
 }
 
-static int dump_nic_stats(portid_t pid)
+static int dump_nic_stats(char *name, int namelen)
 {
     int err;
     size_t len = 0;
     netif_nic_stats_get_t get, *p_get = NULL;
 
-    err = dpvs_getsockopt(SOCKOPT_NETIF_GET_PORT_STATS, &pid, sizeof(pid), (void **)&p_get, &len);
+    err = dpvs_getsockopt(SOCKOPT_NETIF_GET_PORT_STATS, name, namelen,
+            (void **)&p_get, &len);
     if (err != EDPVS_OK || !p_get || !len)
         return err;
     get = *p_get; 
@@ -336,13 +301,13 @@ static int dump_nic_stats(portid_t pid)
     return EDPVS_OK;
 }
 
-static int dump_nic_verbose(portid_t pid)
+static int dump_nic_verbose(char *name, int namelen)
 {
     int err;
     size_t len = 0;
     netif_nic_ext_get_t *ext_get = NULL;
 
-    err = dpvs_getsockopt(SOCKOPT_NETIF_GET_PORT_EXT_INFO, &pid, sizeof(pid),
+    err = dpvs_getsockopt(SOCKOPT_NETIF_GET_PORT_EXT_INFO, name, namelen,
         (void **)&ext_get, &len);
     if (err != EDPVS_OK || !ext_get || !len)
         return err;
@@ -429,14 +394,14 @@ static inline void calc_nic_stats_velocity(int t,
         velocity->q_errors[ii] = (stop->q_errors[ii] - start->q_errors[ii])/t;
 }
 
-static int dump_nic_stats_velocity(portid_t pid, int interval, int count)
+static int dump_nic_stats_velocity(char *name, int namelen, int interval, int count)
 {
     int tk = 1, err;
     size_t len = 0;
     netif_nic_stats_get_t get1, get2, velocity, *p_get = NULL;
 
     while (true) {
-        err = dpvs_getsockopt(SOCKOPT_NETIF_GET_PORT_STATS, &pid, sizeof(pid),
+        err = dpvs_getsockopt(SOCKOPT_NETIF_GET_PORT_STATS, name, namelen,
                 (void **)&p_get, &len);
         if (err != EDPVS_OK || !p_get || !len)
             return err;
@@ -445,7 +410,7 @@ static int dump_nic_stats_velocity(portid_t pid, int interval, int count)
     
         sleep(interval);
     
-        err = dpvs_getsockopt(SOCKOPT_NETIF_GET_PORT_STATS, &pid, sizeof(pid),
+        err = dpvs_getsockopt(SOCKOPT_NETIF_GET_PORT_STATS, name, namelen,
                 (void **)&p_get, &len);
         if (err != EDPVS_OK || !p_get || !len)
             return err;
@@ -481,15 +446,13 @@ static int dump_nic_stats_velocity(portid_t pid, int interval, int count)
     return EDPVS_OK;
 }
 
-static int dump_bond_status(portid_t pid)
+static int dump_bond_status(char *name, int namelen)
 {
     int i, err;
     size_t len = 0;
     netif_bond_status_get_t *p_get = NULL;
-    if (pid < g_nports.bond_pid_base || pid > g_nports.bond_pid_end)
-        return EDPVS_INVAL;
 
-    err = dpvs_getsockopt(SOCKOPT_NETIF_GET_BOND_STATUS, &pid, sizeof(pid),
+    err = dpvs_getsockopt(SOCKOPT_NETIF_GET_BOND_STATUS, name, namelen,
             (void **)(&p_get), &len);
     if (err != EDPVS_OK || !p_get || !len)
         return err;
@@ -668,27 +631,30 @@ static int dump_cpu_stats_velocity(lcoreid_t cid, int interval, int count)
     return EDPVS_OK;
 }
 
-static int link_nic_show(portid_t pid, const struct link_param *param)
+static int link_nic_show(struct link_param *param)
 {
     int err;
-    if ((err = dump_nic_basic(pid)) != EDPVS_OK)
+    if ((err = dump_nic_basic(param->dev_name, sizeof(param->dev_name))) != EDPVS_OK)
         return err;
     if (param->stats.enabled) {
         if (!param->stats.interval) {
-            if((err = dump_nic_stats(pid)) != EDPVS_OK)
+            if((err = dump_nic_stats(param->dev_name, sizeof(param->dev_name)))
+                        != EDPVS_OK)
                 return err;
         } else {
             /* FIXME: possible infinite loop here  */
-            if ((err = dump_nic_stats_velocity(pid, param->stats.interval,
-                            param->stats.count)) != EDPVS_OK)
+            if ((err = dump_nic_stats_velocity(param->dev_name, sizeof(param->dev_name),
+                        param->stats.interval, param->stats.count)) != EDPVS_OK)
                 return err;
         }
     }
     if (param->verbose)
-        if ((err = dump_nic_verbose(pid)) != EDPVS_OK)
+        if ((err = dump_nic_verbose(param->dev_name,
+                    sizeof(param->dev_name))) != EDPVS_OK)
             return err;
     if (param->status) {
-        if ((err = dump_bond_status(pid) != EDPVS_OK))
+        if ((err = dump_bond_status(param->dev_name,
+                    sizeof(param->dev_name))) != EDPVS_OK)
             return err;
     }
     return EDPVS_OK;
@@ -720,39 +686,25 @@ static int link_show(struct link_param *param)
 {
     assert(param);
 
-    int ii, err, ret, cnt;
-    unsigned id = 0;
-    bool dev_specified = false;
-    netif_lcore_mask_get_t lcores, *p_lcores = NULL;
-    size_t len = 0;
+    int ii, err, ret;
 
     switch (param->dev_type) {
         case LINK_DEVICE_NIC:
         {
-            if (get_netif_port_nb() < 0)
-                return EDPVS_INVAL;
-
-            if (param->dev_name[0]) { /* device name specified */
-                if (link_check_dev_name(LINK_DEVICE_NIC, param->dev_name, &id)) {
-                    link_help();
-                    return EDPVS_INVAL;
-                }
-                dev_specified = true;
-            }
-            if (dev_specified) { /* show information of specified NIC */
-                if (id < g_nports.nic_num)
-                    return link_nic_show(id, param);
-                else {
-                    fprintf(stderr, "Device %s not exist.\n", param->dev_name);
-                    return EDPVS_NOTEXIST;
-                }
+            if (param->dev_name[0]) { /* show information of specified NIC */
+                return link_nic_show(param);
             } else { /* show infomation of all NIC */
+                if (get_netif_port_list() < 0)
+                    return EDPVS_INVAL;
                 ret = EDPVS_OK;
-                for (ii = 0; ii < g_nports.nic_num; ii++) {
-                    snprintf(param->dev_name, sizeof(param->dev_name), "dpdk%d", ii);
-                    err = link_nic_show(ii, param);
+                for (ii = 0; ii < g_nic_list->nic_num && ii < NETIF_MAX_PORTS; ii++) {
+                    // Todo: sort the nic list?
+                    snprintf(param->dev_name, sizeof(param->dev_name),
+                            "%s", g_nic_list->idname[ii].name);
+                    err = link_nic_show(param);
                     if (err) {
-                        fprintf(stderr, "Fail to get information for dpdk%d\n", ii);
+                        fprintf(stderr, "Fail to get information for %s\n",
+                                param->dev_name);
                         ret = err;
                     }
                 }
@@ -762,33 +714,28 @@ static int link_show(struct link_param *param)
         }
         case LINK_DEVICE_CPU:
         {
-            err = dpvs_getsockopt(SOCKOPT_NETIF_GET_LCORE_MASK, NULL, 0,
-                    (void **)&p_lcores, &len);
-            if (EDPVS_OK != err || !p_lcores || !len) {
-                fprintf(stderr, "Fail to get configured CPU information: %s.\n",
-                        dpvs_strerror(err));
-                return err;
-            }
-            lcores = *p_lcores;
-            dpvs_sockopt_msg_free((void *)p_lcores);
-
-            if (param->dev_name[0]) { /* device name speicified */
-                if(link_check_dev_name(LINK_DEVICE_CPU, param->dev_name, &id)) {
+            unsigned id = 0;
+            if (param->dev_name[0]) { /* show information of specified CPU */
+                if (link_get_cpu_id(param->dev_name, &id)) {
                     link_help();
                     return EDPVS_INVAL;
                 }
-                dev_specified = true;
-            }
-            if (dev_specified) { /* show information of specified CPU */
-                if (id == lcores.master_lcore_id ||
-                        lcores.slave_lcore_mask & (1L << id) ||
-                        lcores.isol_rx_lcore_mask & (1L << id))
-                    return link_cpu_show(id, param);
-                else {
-                    fprintf(stderr, "Device %s not exist.\n", param->dev_name);
-                    return EDPVS_NOTEXIST;
-                }
+                return link_cpu_show(id, param);
             } else { /* show information of all CPU */
+                size_t len = 0;
+                int cnt;
+                netif_lcore_mask_get_t lcores, *p_lcores = NULL;
+
+                err = dpvs_getsockopt(SOCKOPT_NETIF_GET_LCORE_MASK, NULL, 0,
+                        (void **)&p_lcores, &len);
+                if (EDPVS_OK != err || !p_lcores || !len) {
+                    fprintf(stderr, "Fail to get configured CPU information: %s.\n",
+                            dpvs_strerror(err));
+                    return err;
+                }
+                lcores = *p_lcores;
+                dpvs_sockopt_msg_free((void *)p_lcores);
+
                 ret = EDPVS_OK;
 
                 printf("<< Controll Plane >>\n");
@@ -950,13 +897,7 @@ static int link_nic_set_tc_ingress(const char *name, const char *value)
 
 static int link_bond_add_bond_slave(const char *name, const char *value)
 {
-    unsigned dev_id;
     netif_bond_set_t cfg;
-
-    if (link_check_dev_name(LINK_DEVICE_NIC, value, &dev_id)) {
-        printf("invalid device name: %s\n", value);
-        return EDPVS_INVAL;
-    }
 
     memset(&cfg, 0, sizeof(cfg));
     strncpy(cfg.name, name, sizeof(cfg.name) - 1);
@@ -970,13 +911,7 @@ static int link_bond_add_bond_slave(const char *name, const char *value)
 
 static int link_bond_del_bond_slave(const char *name, const char *value)
 {
-    unsigned dev_id;
     netif_bond_set_t cfg;
-
-    if (link_check_dev_name(LINK_DEVICE_NIC, value, &dev_id)) {
-        printf("invalid device name: %s\n", value);
-        return EDPVS_INVAL;
-    }
 
     memset(&cfg, 0, sizeof(cfg));
     strncpy(cfg.name, name, sizeof(cfg.name) - 1);
@@ -1013,13 +948,7 @@ static int link_bond_set_mode(const char *name, const char *value)
 
 static int link_bond_set_primary(const char *name, const char *value)
 {
-    unsigned dev_id;
     netif_bond_set_t cfg;
-
-    if (link_check_dev_name(LINK_DEVICE_NIC, value, &dev_id)){
-        printf("invalid device name: %s\n", value);
-        return EDPVS_INVAL;
-    }
 
     memset(&cfg, 0, sizeof(cfg));
     strncpy(cfg.name, name, sizeof(cfg.name) - 1);
@@ -1124,32 +1053,17 @@ static int link_bond_set_link_up_prop(const char *name, const char *value)
 
 static int link_add(struct link_param *param)
 {
-    unsigned dev_id;
     assert(param);
 
     switch (param->dev_type) {
         case LINK_DEVICE_NIC:
         {
-            if (get_netif_port_nb() < 0)
-                return EDPVS_INVAL;
-            if (link_check_dev_name(LINK_DEVICE_NIC, param->dev_name, &dev_id) < 0) {
-                fprintf(stderr, "invalid device name '%s'\n", param->dev_name);
-                return EDPVS_INVAL;
-            }
-
             if (strcmp(param->item, "bond-slave") == 0)
                 link_bond_add_bond_slave(param->dev_name, param->value);
-            break;
+            return EDPVS_OK;
         }
         case LINK_DEVICE_CPU:
-        {
-            if (link_check_dev_name(LINK_DEVICE_CPU, param->dev_name, &dev_id)) {
-                fprintf(stderr, "invalid device name '%s'\n", param->dev_name);
-                return EDPVS_INVAL;
-            }
-
-            break;
-        }
+            return EDPVS_OK;
         default:
         {
             fprintf(stderr, "Unsupported device type.\n");
@@ -1162,32 +1076,17 @@ static int link_add(struct link_param *param)
 
 static int link_del(struct link_param *param)
 {
-    unsigned dev_id;
     assert(param);
 
     switch (param->dev_type) {
         case LINK_DEVICE_NIC:
         {
-            if (get_netif_port_nb() < 0)
-                return EDPVS_INVAL;
-            if (link_check_dev_name(LINK_DEVICE_NIC, param->dev_name, &dev_id) < 0) {
-                fprintf(stderr, "invalid device name '%s'\n", param->dev_name);
-                return EDPVS_INVAL;
-            }
-
             if (strcmp(param->item, "bond-slave") == 0)
                 link_bond_del_bond_slave(param->dev_name, param->value);
-            break;
+            return EDPVS_OK;
         }
         case LINK_DEVICE_CPU:
-        {
-            if (link_check_dev_name(LINK_DEVICE_CPU, param->dev_name, &dev_id)) {
-                fprintf(stderr, "invalid device name '%s'\n", param->dev_name);
-                return EDPVS_INVAL;
-            }
-
-            break;
-        }
+            return EDPVS_OK;
         default:
         {
             fprintf(stderr, "Unsupported device type.\n");
@@ -1200,19 +1099,11 @@ static int link_del(struct link_param *param)
 
 static int link_set(struct link_param *param)
 {
-    unsigned dev_id;
     assert(param);
 
     switch (param->dev_type) {
         case LINK_DEVICE_NIC:
         {
-            if (get_netif_port_nb() < 0)
-                return EDPVS_INVAL;
-            if (link_check_dev_name(LINK_DEVICE_NIC, param->dev_name, &dev_id) < 0) {
-                fprintf(stderr, "invalid device name '%s'\n", param->dev_name);
-                return EDPVS_INVAL;
-            }
-
             if (strcmp(param->item, "promisc") == 0)
                 link_nic_set_promisc(param->dev_name, param->value);
             else if (strcmp(param->item, "forward2kni") == 0)
@@ -1241,17 +1132,10 @@ static int link_set(struct link_param *param)
                 fprintf(stderr, "invalid parameter name '%s'\n", param->item);
                 return EDPVS_INVAL;
             }
-            break;
+            return EDPVS_OK;
         }
         case LINK_DEVICE_CPU:
-        {
-            if (link_check_dev_name(LINK_DEVICE_CPU, param->dev_name, &dev_id)) {
-                fprintf(stderr, "invalid device name '%s'\n", param->dev_name);
-                return EDPVS_INVAL;
-            }
-
-            break;
-        }
+            return EDPVS_OK;
         default:
         {
             fprintf(stderr, "Unsupported device type.\n");
@@ -1280,8 +1164,6 @@ static int link_do_cmd(struct dpip_obj *obj, dpip_cmd_t cmd,
         return link_del(&param);
     case DPIP_CMD_SET:
         return link_set(&param);
-    case DPIP_CMD_FLUSH:
-        return EDPVS_NOTSUPP;
     case DPIP_CMD_SHOW:
         return link_show(&param);
     default:
@@ -1290,9 +1172,9 @@ static int link_do_cmd(struct dpip_obj *obj, dpip_cmd_t cmd,
 }
 
 struct dpip_obj dpip_link = {
-    .name    = "link",
+    .name   = "link",
     .do_cmd = link_do_cmd,
-    .help = link_help,
+    .help   = link_help,
 };
 
 static void __init addr_init(void)
@@ -1302,5 +1184,7 @@ static void __init addr_init(void)
 
 static void __exit addr_exit(void)
 {
+    if (g_nic_list)
+        free(g_nic_list);
     dpip_unregister_obj(&dpip_link);
 }


### PR DESCRIPTION
use port name instead of ID to communicate between dpip and dpvs,
by @yuwenchao.