### PR TITLE
netif: make dpvs work with over 64 CPUs

### DIFF
--- a/src/ctrl.c
+++ b/src/ctrl.c
@@ -845,6 +845,9 @@ static inline int msg_init(void)
     char ring_name[16];
     char buf[4096];
 
+    if (DPVS_MAX_LCORE >= 64)
+        return EDPVS_NOTSUPP;
+
     /* lcore mask init */
     slave_lcore_mask = 0;
     slave_lcore_nb = 0;

--- a/src/netif.c
+++ b/src/netif.c
@@ -3729,7 +3729,7 @@ static int netif_loop(void *dummy)
     uint64_t loop_start, loop_end;
 #endif
 
-    assert(LCORE_ID_ANY != cid && cid < DPVS_MAX_LCORE);
+    assert(LCORE_ID_ANY != cid);
 
     try_isol_rxq_lcore_loop();
     if (0 == lcore_conf[lcore2index[cid]].nports) {


### PR DESCRIPTION
DPVS cannot work with over 64 CPUs now because dpvs multicast msg uses a 64-bit lcore mask. This change makes dpvs work on a server with over 64 CPUs  when DPVS_MAX_LCORE is not greater than 64.