### PR TITLE
Fix build failure with GCC-7

### DIFF
--- a/src/inetaddr.c
+++ b/src/inetaddr.c
@@ -601,7 +601,7 @@ static void ifa_fill_param(int af, struct inet_addr_param *param,
     param->bcast    = ifa->bcast;
     param->scope    = ifa->scope;
     param->flags    = ifa->flags;
-    snprintf(param->ifname, sizeof(param->ifname), "%s", ifa->idev->dev->name);
+    snprintf(param->ifname, sizeof(param->ifname), "%.15s", ifa->idev->dev->name);
 
     if (ifa->flags & IFA_F_PERMANENT) {
         param->valid_lft = param->prefered_lft = 0;

--- a/src/ip_tunnel.c
+++ b/src/ip_tunnel.c
@@ -170,7 +170,7 @@ static struct netif_port *tunnel_create(struct ip_tunnel_tab *tab,
         return NULL;
 
     /* syn back ifname, it may generated. */
-    snprintf(params.ifname, IFNAMSIZ, "%s", dev->name);
+    snprintf(params.ifname, IFNAMSIZ, "%.15s", dev->name);
 
     tnl = netif_priv(dev);
 


### PR DESCRIPTION
GCC was detecting trucated strings. This was corrected by specifying a
character limit in the string format of the print command.