### PR TITLE
conn_ctrl_term() in Line 1449 should call sockopt_unregister() function

### DIFF
--- a/src/ipvs/ip_vs_conn.c
+++ b/src/ipvs/ip_vs_conn.c
@@ -1446,7 +1446,6 @@ static void conn_ctrl_term(void)
         list_del_init(&calst->ca_list);
         rte_free(calst);
     }
-    // Here should call sockopt_unregister() function.
     sockopt_unregister(&conn_sockopts);
     unregister_conn_get_msg();
 }

--- a/src/ipvs/ip_vs_conn.c
+++ b/src/ipvs/ip_vs_conn.c
@@ -1446,8 +1446,8 @@ static void conn_ctrl_term(void)
         list_del_init(&calst->ca_list);
         rte_free(calst);
     }
-
-    sockopt_register(&conn_sockopts);
+    // Here should call sockopt_unregister() function.
+    sockopt_unregister(&conn_sockopts);
     unregister_conn_get_msg();
 }
 


### PR DESCRIPTION
修改`conn_ctrl_term()`中的一个小bug：这个函数功能是要释放资源，而函数体中却调用了`sockopt_register()`函数，应该修改为`sockopt_unregister()`函数。

比如，系统内存分配不足时，会导致重复调用`sockopt_register`函数，这样会误报错误信息，对开发者 debug 时不太友好。