### PR TITLE
ipvs-conn: fix typo when unregister sockopt

### DIFF
--- a/src/ipvs/ip_vs_conn.c
+++ b/src/ipvs/ip_vs_conn.c
@@ -1446,6 +1446,7 @@ static void conn_ctrl_term(void)
         list_del_init(&calst->ca_list);
         rte_free(calst);
     }
+
     sockopt_unregister(&conn_sockopts);
     unregister_conn_get_msg();
 }

--- a/src/ipvs/ip_vs_conn.c
+++ b/src/ipvs/ip_vs_conn.c
@@ -1446,7 +1446,6 @@ static void conn_ctrl_term(void)
         list_del_init(&calst->ca_list);
         rte_free(calst);
     }
-    // Here should call sockopt_unregister() function.
     sockopt_unregister(&conn_sockopts);
     unregister_conn_get_msg();
 }

--- a/src/ipvs/ip_vs_conn.c
+++ b/src/ipvs/ip_vs_conn.c
@@ -1446,8 +1446,8 @@ static void conn_ctrl_term(void)
         list_del_init(&calst->ca_list);
         rte_free(calst);
     }
-
-    sockopt_register(&conn_sockopts);
+    // Here should call sockopt_unregister() function.
+    sockopt_unregister(&conn_sockopts);
     unregister_conn_get_msg();
 }
 


### PR DESCRIPTION
修改`ip_vs_conn.c`模块中的`conn_ctrl_term()`函数中的`sockopt_register` 为 `sockopt_unregister`