### PR TITLE
dpdk.mk: support BCM driver rte_pmd_bnxt

### DIFF
--- a/src/dpdk.mk
+++ b/src/dpdk.mk
@@ -40,7 +40,7 @@ LIBS += -L $(DPDKDIR)/lib
 
 LIBS += -Wl,--no-as-needed -fvisibility=default \
         -Wl,--whole-archive -lrte_pmd_vmxnet3_uio -lrte_pmd_i40e -lrte_pmd_ixgbe \
-		-lrte_pmd_e1000 -lrte_pmd_ring -lrte_pmd_bond -lrte_ethdev -lrte_ip_frag \
+		-lrte_pmd_e1000 -lrte_pmd_bnxt -lrte_pmd_ring -lrte_pmd_bond -lrte_ethdev -lrte_ip_frag \
 		-Wl,--whole-archive -lrte_hash -lrte_kvargs -Wl,-lrte_mbuf -lrte_eal \
 		-Wl,-lrte_mempool -lrte_ring -lrte_cmdline -lrte_cfgfile -lrte_kni \
 		-lrte_mempool_ring -lrte_timer -lrte_net -Wl,-lrte_pmd_virtio \


### PR DESCRIPTION
Support Broadcom NIC driver rte_pmd_bnxt.