### PR TITLE
dpvs: fix a boring issue with two same ip configured.

### DIFF
--- a/src/route.c
+++ b/src/route.c
@@ -165,7 +165,8 @@ static struct route_entry *route_local_lookup(uint32_t dest, const struct netif_
     struct route_entry *route_node;
     hashkey = route_local_hashkey(dest, port);
     list_for_each_entry(route_node, &this_local_route_table[hashkey], list){
-        if ((dest == route_node->dest.s_addr) && (port->id == route_node->port->id)) {
+        if ((dest == route_node->dest.s_addr)
+                && (port ? (port->id == route_node->port->id) : true)) {
             rte_atomic32_inc(&route_node->refcnt);
             return route_node;
         }

--- a/src/route.c
+++ b/src/route.c
@@ -165,7 +165,7 @@ static struct route_entry *route_local_lookup(uint32_t dest, const struct netif_
     struct route_entry *route_node;
     hashkey = route_local_hashkey(dest, port);
     list_for_each_entry(route_node, &this_local_route_table[hashkey], list){
-        if (dest == route_node->dest.s_addr) {
+        if ((dest == route_node->dest.s_addr) && (port->id == route_node->port->id)) {
             rte_atomic32_inc(&route_node->refcnt);
             return route_node;
         }


### PR DESCRIPTION
Add netif compare to make lookup local route happy.
Issue produce:
[root@localhost bin]# ./dpip vlan add dpdk0.100 link dpdk0 id 100
[root@localhost bin]# ./dpip addr add 192.168.1.101/24 dev dpdk0.100
[root@localhost bin]# ./dpip addr add 192.168.1.101/24 dev dpdk0
[root@localhost bin]# ./dpip addr del 192.168.1.101/24 dev dpdk0.100
[root@localhost bin]# ./dpip route show
inet 192.168.1.101/32 via 0.0.0.0 src 0.0.0.0 dev dpdk0.100 mtu 1500 tos
0 scope host metric 0 proto auto
inet 192.168.1.0/24 via 0.0.0.0 src 192.168.1.101 dev dpdk0 mtu 1500 tos
0 scope link metric 0 proto auto