### PR TITLE
add udp/tunnel RSS support,supplement dpvs_strerror

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -45,10 +45,15 @@ const char *dpvs_strerror(int err)
         { EDPVS_NOTEXIST,       "not exist" },
         { EDPVS_INVPKT,         "invalid packet" },
         { EDPVS_DROP,           "packet dropped" },
+        { EDPVS_NOPROT,         "no protocol" },
+        { EDPVS_NOROUTE,        "no route" },
+        { EDPVS_DEFRAG,         "defragment error" },
+        { EDPVS_FRAG,           "fragment error" },
         { EDPVS_DPDKAPIFAIL,    "failed dpdk api" },
         { EDPVS_IDLE,           "nothing to do" },
         { EDPVS_BUSY,           "resource busy" },
         { EDPVS_NOTSUPP,        "not support" },
+        { EDPVS_RESOURCE,       "no resource" },
         { EDPVS_OVERLOAD,       "overloaded" },
         { EDPVS_NOSERV,         "no service" },
         { EDPVS_DISABLED,       "disabled" },
@@ -58,11 +63,12 @@ const char *dpvs_strerror(int err)
         { EDPVS_IO,             "I/O error" },
         { EDPVS_MSG_FAIL,       "msg callback failed"},
         { EDPVS_MSG_DROP,       "msg dropped"},
-        { EDPVS_SYSCALL,        "system call failed"},
-        { EDPVS_KNICONTINUE,    "kni to continue"},
         { EDPVS_PKTSTOLEN,      "stolen packet"},
-        { EDPVS_INPROGRESS,     "in progress"},
+        { EDPVS_SYSCALL,        "system call failed"},
         { EDPVS_NODEV,          "no such device"},
+
+        { EDPVS_KNICONTINUE,    "kni to continue"},
+        { EDPVS_INPROGRESS,     "in progress"},
     };
     int i;
 


### PR DESCRIPTION
When I tested UOA, I found that uperf can only reach more than 4,000 sessions at a time. This is because in dpvs, RSS does not support UDP mode yet, so RSS use IP to hash. That is, all uperf traffic hits the same CPU.
