### PR TITLE
fix bug in <case IP_VS_SO_SET_EDITDEST>

### DIFF
--- a/tools/keepalived/keepalived/check/ipvswrapper.c
+++ b/tools/keepalived/keepalived/check/ipvswrapper.c
@@ -446,7 +446,7 @@ ipvs_talk(int cmd)
 			break;
 		case IP_VS_SO_SET_EDITDEST:
 			if ((result = ipvs_update_dest(srule, drule)) &&
-			    (errno == ENOENT))
+			    (result == EDPVS_NOTEXIST))
 				result = ipvs_add_dest(srule, drule);
 			break;
 	}


### PR DESCRIPTION
case: 当修改完keepalived.conf中的virtual_server_group中的ip或者port之后，reload keepalived，发现没有real_server。