### PR TITLE
version: get version from git tags or commit id if no tag exists.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -23,7 +23,12 @@
 
 TARGET := dpvs
 
-VERSION_STRING := $(shell ./VERSION)
+ifneq ("$(wildcard VERSION)","")
+    VERSION_STRING := $(shell ./VERSION)
+else
+    VERSION_STRING := $(shell git describe --tags --always)
+endif
+
 DATE_STRING := $(shell date +%Y.%m.%d.%H:%M:%S)
 
 # same path of THIS Makefile


### PR DESCRIPTION
Get DPVS version from git tags or commit id if no tag exists instead of maintaining the VERSION shell script.