### PR TITLE
fix dump check bug:

### DIFF
--- a/tools/keepalived/keepalived/check/check_http.c
+++ b/tools/keepalived/keepalived/check/check_http.c
@@ -71,13 +71,16 @@ free_http_get_check(void *data)
 void
 dump_http_get_check(void *data)
 {
+	if (!data)
+		return;
 	http_checker_t *http_get_chk = CHECKER_DATA(data);
 
 	if (http_get_chk->proto == PROTO_HTTP)
 		log_message(LOG_INFO, "   Keepalive method = HTTP_GET");
 	else
 		log_message(LOG_INFO, "   Keepalive method = SSL_GET");
-	dump_conn_opts (CHECKER_GET_CO());
+	if (CHECKER_CO(data))
+		dump_conn_opts(CHECKER_CO(data));
 	log_message(LOG_INFO, "   Nb get retry = %d", http_get_chk->nb_get_retry);
 	log_message(LOG_INFO, "   Delay before retry = %lu",
 	       http_get_chk->delay_before_retry/TIMER_HZ);

--- a/tools/keepalived/keepalived/check/check_tcp.c
+++ b/tools/keepalived/keepalived/check/check_tcp.c
@@ -48,9 +48,9 @@ void
 dump_tcp_check(void *data)
 {
 	log_message(LOG_INFO, "   Keepalive method = TCP_CHECK");
-	if (!data)
+	if (!data || !CHECKER_CO(data))
 		return;
-	dump_conn_opts (CHECKER_GET_CO());
+	dump_conn_opts(CHECKER_CO(data));
 }
 
 void


### PR DESCRIPTION
1.No matter how many checks dump, it only shows the last one
2.If dump tcp and misc check, and the last one is not tcp check, may cause coredump for access null pointer.

$ sudo gdb ../dpvs/bin/keepalived /core.129771 
GNU gdb (GDB) Red Hat Enterprise Linux 7.6.1-100.el7
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-redhat-linux-gnu".
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>...
Reading symbols from /home/dpvs/dpvs_conhash/dpvs_dpdk/dpvs/bin/keepalived...done.
[New LWP 129771]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
Core was generated by `/home/dpvs/dpvs_conhash/dpvs_dpdk/sre_scripts/../dpvs/bin/keepalived -d -C -f /'.
Program terminated with signal 11, Segmentation fault.
#0  0x000000000042761c in inet_sockaddrtos2 (addr=0x0, addr_str=0x64ada0 <addr_str.4404> "10.54.75.41") at utils.c:217
217     utils.c: No such file or directory.
Missing separate debuginfos, use: debuginfo-install glibc-2.17-196.el7.x86_64 keyutils-libs-1.5.8-3.el7.x86_64 krb5-libs-1.15.1-8.el7.x86_64 libcom_err-1.42.9-10.el7.x86_64 libselinux-2.5-11.el7.x86_64 nss-softokn-freebl-3.28.3-8.el7_4.x86_64 openssl-libs-1.0.2k-8.el7.x86_64 pcre-8.32-17.el7.x86_64 zlib-1.2.7-17.el7.x86_64
(gdb) bt
#0  0x000000000042761c in inet_sockaddrtos2 (addr=0x0, addr_str=0x64ada0 <addr_str.4404> "10.54.75.41") at utils.c:217
#1  0x0000000000427705 in inet_sockaddrtopair (addr=0x0) at utils.c:261
#2  0x0000000000406d79 in dump_conn_opts (conn=0x0) at check_api.c:62
#3  0x0000000000405c06 in dump_tcp_check (data=0x12ac090) at check_tcp.c:53
#4  0x0000000000406d5f in dump_checker (data=0x12ac090) at check_api.c:56
#5  0x000000000042ba87 in dump_list (l=0x12a78b0) at list.c:102
#6  0x00000000004073d9 in dump_checkers_queue () at check_api.c:213
#7  0x000000000040db71 in dump_check_data (data=0x12a7540) at check_data.c:564
#8  0x00000000004060d6 in start_check () at check_daemon.c:141
#9  0x0000000000406482 in start_check_child () at check_daemon.c:308
#10 0x00000000004062df in check_respawn_thread (thread=0x7ffd6a86a2c0) at check_daemon.c:240
#11 0x0000000000429949 in thread_call (thread=0x7ffd6a86a2c0) at scheduler.c:761
#12 0x000000000042997a in launch_scheduler () at scheduler.c:784
#13 0x000000000040370f in main (argc=7, argv=0x7ffd6a86a418) at main.c:307
(gdb) bt full
#0  0x000000000042761c in inet_sockaddrtos2 (addr=0x0, addr_str=0x64ada0 <addr_str.4404> "10.54.75.41") at utils.c:217
        addr_ip = 0x0
#1  0x0000000000427705 in inet_sockaddrtopair (addr=0x0) at utils.c:261
        addr_str = "10.54.75.41", '\000' <repeats 35 times>
        ret = "[10.54.75.41]:6080", '\000' <repeats 44 times>
#2  0x0000000000406d79 in dump_conn_opts (conn=0x0) at check_api.c:62
No locals.
#3  0x0000000000405c06 in dump_tcp_check (data=0x12ac090) at check_tcp.c:53
No locals.
#4  0x0000000000406d5f in dump_checker (data=0x12ac090) at check_api.c:56
        checker = 0x12ac090
#5  0x000000000042ba87 in dump_list (l=0x12a78b0) at list.c:102
        e = 0x12ac0f0
#6  0x00000000004073d9 in dump_checkers_queue () at check_api.c:213
No locals.
#7  0x000000000040db71 in dump_check_data (data=0x12a7540) at check_data.c:564
No locals.
#8  0x00000000004060d6 in start_check () at check_daemon.c:141
No locals.
#9  0x0000000000406482 in start_check_child () at check_daemon.c:308
        pid = 0
        ret = 0
#10 0x00000000004062df in check_respawn_thread (thread=0x7ffd6a86a2c0) at check_daemon.c:240
        pid = 129770
#11 0x0000000000429949 in thread_call (thread=0x7ffd6a86a2c0) at scheduler.c:761
No locals.
#12 0x000000000042997a in launch_scheduler () at scheduler.c:784
        thread = {id = 6, type = 5 '\005', next = 0x0, prev = 0x0, master = 0x12a7090, func = 0x406267 <check_respawn_thread>, arg = 0x0, sands = {tv_sec = 1532955098, tv_usec = 603925}, u = {val = 129770, fd = 129770, c = {pid = 129770, status = 139}}}
#13 0x000000000040370f in main (argc=7, argv=0x7ffd6a86a418) at main.c:307
No locals.