### PR TITLE
ipvs_tunnel: addtunnel port number limit, because the number of tunne…

### DIFF
--- a/include/netif.h
+++ b/include/netif.h
@@ -361,4 +361,6 @@ static inline char *eth_addr_dump(const struct ether_addr *ea,
     return buf;
 }
 
+portid_t netif_port_count(void);
+
 #endif /* __DPVS_NETIF_H__ */

--- a/src/ip_tunnel.c
+++ b/src/ip_tunnel.c
@@ -161,6 +161,12 @@ static struct netif_port *tunnel_create(struct ip_tunnel_tab *tab,
     assert(tab && ops && par);
     params = *par; /* may modified */
 
+    if (netif_port_count() >= NETIF_MAX_PORTS) {
+        RTE_LOG(ERR, TUNNEL, "%s: exceeding specification limits(%d)",
+            __func__, NETIF_MAX_PORTS);
+        return NULL;
+    }
+
     /* set ifname template if not assigned. */
     if (!strlen(params.ifname))
         snprintf(params.ifname, IFNAMSIZ, "%s%%d", ops->kind);

--- a/src/netif.c
+++ b/src/netif.c
@@ -2609,6 +2609,11 @@ static inline portid_t netif_port_id_alloc(void)
     return port_id_end++;
 }
 
+portid_t netif_port_count(void)
+{
+    return port_id_end;
+}
+
 struct netif_port *netif_alloc(size_t priv_size, const char *namefmt,
                                unsigned int nrxq, unsigned int ntxq,
                                void (*setup)(struct netif_port *))


### PR DESCRIPTION
…l ports by exceeding NETIF_MAX_PORTS will lead to crash.