### PR TITLE
Add ICMP protocol for show blacklist.

### DIFF
--- a/tools/ipvsadm/ipvsadm.c
+++ b/tools/ipvsadm/ipvsadm.c
@@ -2049,6 +2049,8 @@ static void print_service_and_blklsts(struct dp_vs_blklst_conf *blklst)
 		printf("%s:%-8s %-8s %-20s\n" , pbuf_v, port, "TCP", pbuf_d);
 	else if(blklst->proto ==IPPROTO_UDP)
 		printf("%s:%-8s %-8s %-20s\n" , pbuf_v, port, "UDP", pbuf_d);
+	else if (blklst->proto == IPPROTO_ICMP)
+		printf("%s:%-8s %-8s %-20s\n" , pbuf_v, port, "ICMP", pbuf_d);
 	else
 		printf("proto not support!");
 }


### PR DESCRIPTION
在查询黑名单时，不支持icmp协议。
# ./ipvsadm -B
VIP:VPORT            PROTO    BLACKLIST           
0.0.0.0:0        UDP      172.1.1.1           
0.0.0.0:0        UDP      192.168.1.1         
0.0.0.0:0        TCP      172.1.1.1           
0.0.0.0:0        TCP      192.168.1.1         
proto not support!proto not support!