### PR TITLE
Tunnel iif

### DIFF
--- a/tools/keepalived/keepalived/check/ipvswrapper.c
+++ b/tools/keepalived/keepalived/check/ipvswrapper.c
@@ -932,6 +932,7 @@ ipvs_blklst_vsg_cmd(int cmd, list vs_group, virtual_server_t * vs, blklst_addr_g
 static int
 ipvs_blklst_cmd(int cmd, list vs_group, virtual_server_t * vs)
 {
+        uint32_t ip_addr = 0;
         blklst_addr_group *blklst_group = ipvs_get_blklst_group_by_name(vs->blklst_addr_gname,
                                                         check_data->blklst_group);
         if (!blklst_group) {
@@ -950,8 +951,14 @@ ipvs_blklst_cmd(int cmd, list vs_group, virtual_server_t * vs)
                         srule->af = vs->addr.ss_family;
                         if (vs->addr.ss_family == AF_INET6)
                                 inet_sockaddrip6(&vs->addr, &srule->addr.in6);
-                        else
-                                srule->addr.ip = inet_sockaddrip4(&vs->addr);
+                        else {
+                            ip_addr = inet_sockaddrip4(&vs->addr);
+                            if (ip_addr == 0xffffffff)
+                                srule->addr.ip = 0;
+                            else
+                                srule->addr.ip = ip_addr;
+                        }
+
                         srule->port = inet_sockaddrport(&vs->addr);
                         ipvs_blklst_group_cmd(cmd, blklst_group);
                 }


### PR DESCRIPTION
virtual_server 不配置IP时，比如SNAT场景，这时通过使用inet_sockaddrip4获取IP，会返回-1 ，而inet_sockaddrip4函数的返回值为uint32_t的，所以-1 会被转换为0xffffffff，从而导致配置黑名单时的virtual_server的IP错误。