### PR TITLE
fix bug: add bklst fail when snat mode.

### DIFF
--- a/tools/keepalived/keepalived/check/ipvswrapper.c
+++ b/tools/keepalived/keepalived/check/ipvswrapper.c
@@ -932,6 +932,7 @@ ipvs_blklst_vsg_cmd(int cmd, list vs_group, virtual_server_t * vs, blklst_addr_g
 static int
 ipvs_blklst_cmd(int cmd, list vs_group, virtual_server_t * vs)
 {
+        uint32_t ip_addr = 0;
         blklst_addr_group *blklst_group = ipvs_get_blklst_group_by_name(vs->blklst_addr_gname,
                                                         check_data->blklst_group);
         if (!blklst_group) {
@@ -950,8 +951,13 @@ ipvs_blklst_cmd(int cmd, list vs_group, virtual_server_t * vs)
                         srule->af = vs->addr.ss_family;
                         if (vs->addr.ss_family == AF_INET6)
                                 inet_sockaddrip6(&vs->addr, &srule->addr.in6);
-                        else
-                                srule->addr.ip = inet_sockaddrip4(&vs->addr);
+                        else {
+                            ip_addr = inet_sockaddrip4(&vs->addr);
+                            if (ip_addr == 0xffffffff)
+                                srule->addr.ip = 0;
+                            else
+                                srule->addr.ip = ip_addr;
+                        }
                         srule->port = inet_sockaddrport(&vs->addr);
                         ipvs_blklst_group_cmd(cmd, blklst_group);
                 }


### PR DESCRIPTION
uint32_t inet_sockaddrip4(struct sockaddr_storage *addr)
在snat场景下，由于其返回类型为uint32_t导致其返回的ip值为0xffffffff，进而导致配置黑名单失败