### PR TITLE
ipvs: add nat-mode support in multi-cores node.

### DIFF
--- a/include/ipvs/conn.h
+++ b/include/ipvs/conn.h
@@ -27,6 +27,11 @@
 #include "ipvs/conn.h"
 #include "ipvs/proto.h"
 #include "ipvs/service.h"
+#include "ipvs/redirect.h"
+
+#define DPVS_CONN_TAB_BITS   20
+#define DPVS_CONN_TAB_SIZE   (1 << DPVS_CONN_TAB_BITS)
+#define DPVS_CONN_TAB_MASK   (DPVS_CONN_TAB_SIZE - 1)
 
 enum {
     DPVS_CONN_DIR_INBOUND = 0,
@@ -35,12 +40,32 @@ enum {
 };
 
 enum {
-    DPVS_CONN_F_HASHED      = 0x0040,
-    DPVS_CONN_F_INACTIVE    = 0x0100,
-    DPVS_CONN_F_SYNPROXY    = 0x8000,
-    DPVS_CONN_F_TEMPLATE    = 0x1000,
-    DPVS_CONN_F_NOFASTXMIT  = 0x2000,
+    DPVS_CONN_F_HASHED          = 0x0040,
+    DPVS_CONN_F_REDIRECT_HASHED = 0x0080,
+    DPVS_CONN_F_INACTIVE        = 0x0100,
+    DPVS_CONN_F_SYNPROXY        = 0x8000,
+    DPVS_CONN_F_TEMPLATE        = 0x1000,
+    DPVS_CONN_F_NOFASTXMIT      = 0x2000,
 };
+
+#define DPVS_CONN_STATES {                                         \
+        DPVS_CONN_STATE(DPVS_CONN_STATE_FREE,    "free"),          \
+        DPVS_CONN_STATE(DPVS_CONN_STATE_VALID,   "valid"),         \
+        DPVS_CONN_STATE(DPVS_CONN_STATE_INVALID, "invalid"),       \
+        DPVS_CONN_STATE(DPVS_CONN_STATE_MAX,     "unknown")        \
+    }
+
+#define DPVS_CONN_STATE(a, b)  a
+enum DPVS_CONN_STATES;
+#undef DPVS_CONN_STATE
+
+typedef uint64_t                dp_vs_conn_id_t;
+
+#define DPVS_CONN_GEN_ID_SHIFT  32
+#define DPVS_CONN_GEN_ID_MASK   ((uint32_t) -1)
+#define DPVS_CONN_IDX_MASK      ((uint32_t) -1)
+#define INVALID_DPVS_CONN_IDX   ((uint32_t) -1)
+#define INVALID_DPVS_CONN_ID    ((uint64_t) -1)
 
 struct dp_vs_conn_param {
     int                 af;
@@ -139,6 +164,7 @@ struct dp_vs_conn {
     rte_atomic32_t dup_ack_cnt;         /* count of repeated ack packets */
 
     /* flags and state transition */
+    volatile uint16_t       conn_state;
     volatile uint16_t       flags;
     volatile uint16_t       state;
     volatile uint16_t       old_state;  /* old state, to be used for state transition
@@ -147,6 +173,9 @@ struct dp_vs_conn {
     struct dp_vs_conn *control;         /* master who controlls me */
     rte_atomic32_t n_control;           /* number of connections controlled by me*/
     uint64_t ctime;                     /* create time */
+
+    /* connection redirect in nat-mode */
+    struct dp_vs_redirect  *redirect;
 } __rte_cache_aligned;
 
 /* for syn-proxy to save all ack packet in conn before rs's syn-ack arrives */
@@ -162,17 +191,17 @@ struct dp_vs_synproxy_ack_pakcet {
 int dp_vs_conn_init(void);
 int dp_vs_conn_term(void);
 
-struct dp_vs_conn * 
-dp_vs_conn_new(struct rte_mbuf *mbuf, 
+struct dp_vs_conn *
+dp_vs_conn_new(struct rte_mbuf *mbuf,
                struct dp_vs_conn_param *param,
                struct dp_vs_dest *dest,
                uint32_t flags);
 int dp_vs_conn_del(struct dp_vs_conn *conn);
 
 struct dp_vs_conn *
-dp_vs_conn_get(int af, uint16_t proto, 
-                const union inet_addr *saddr, 
-                const union inet_addr *daddr, 
+dp_vs_conn_get(int af, uint16_t proto,
+                const union inet_addr *saddr,
+                const union inet_addr *daddr,
                 uint16_t sport, uint16_t dport,
                 int *dir, bool reverse);
 
@@ -189,8 +218,8 @@ void dp_vs_conn_put_no_reset(struct dp_vs_conn *conn);
 void ipvs_conn_keyword_value_init(void);
 void install_ipvs_conn_keywords(void);
 
-static inline void dp_vs_conn_fill_param(int af, uint8_t proto, 
-        const union inet_addr *caddr, const union inet_addr *vaddr, 
+static inline void dp_vs_conn_fill_param(int af, uint8_t proto,
+        const union inet_addr *caddr, const union inet_addr *vaddr,
         uint16_t cport, uint16_t vport, uint16_t ct_dport,
         struct dp_vs_conn_param *param)
 {
@@ -202,7 +231,6 @@ static inline void dp_vs_conn_fill_param(int af, uint8_t proto,
     param->vport    = vport;
     param->ct_dport = ct_dport; /* only for template connection */
 }
-
 
 int dp_vs_check_template(struct dp_vs_conn *ct);
 
@@ -268,5 +296,30 @@ static inline void dp_vs_control_add(struct dp_vs_conn *conn, struct dp_vs_conn 
     conn->control = ctl_conn;
     rte_atomic32_inc(&ctl_conn->n_control);
 }
+
+static inline bool
+dp_vs_conn_is_redirect_hashed(struct dp_vs_conn *conn)
+{
+    return  (conn->flags & DPVS_CONN_F_REDIRECT_HASHED) ? true : false;
+}
+
+static inline void
+dp_vs_conn_set_redirect_hashed(struct dp_vs_conn *conn)
+{
+    conn->flags |= DPVS_CONN_F_REDIRECT_HASHED;
+}
+
+static inline void
+dp_vs_conn_clear_redirect_hashed(struct dp_vs_conn *conn)
+{
+    conn->flags &= ~DPVS_CONN_F_REDIRECT_HASHED;
+}
+
+uint32_t dp_vs_conn_hashkey(int af,
+    const union inet_addr *saddr, uint16_t sport,
+    const union inet_addr *daddr, uint16_t dport,
+    uint32_t mask);
+int dp_vs_conn_pool_size(void);
+int dp_vs_conn_pool_cache_size(void);
 
 #endif /* __DPVS_CONN_H__ */

--- a/include/ipvs/proto.h
+++ b/include/ipvs/proto.h
@@ -34,7 +34,7 @@ struct dp_vs_proto {
     int (*exit)(struct dp_vs_proto *proto);
 
     /* schedule RS and create new conn */
-    int (*conn_sched)(struct dp_vs_proto *proto, 
+    int (*conn_sched)(struct dp_vs_proto *proto,
                       const struct dp_vs_iphdr *iph,
                       struct rte_mbuf *mbuf,
                       struct dp_vs_conn **conn,
@@ -43,12 +43,12 @@ struct dp_vs_proto {
     /* lookup conn by <proto, saddr, sport, daddr, dport>
      * return conn and direction or NULL if miss */
     struct dp_vs_conn *
-        (*conn_lookup)(struct dp_vs_proto *proto, 
+        (*conn_lookup)(struct dp_vs_proto *proto,
                        const struct dp_vs_iphdr *iph,
-                       struct rte_mbuf *mbuf, int *direct, 
-                       bool reverse, bool *drop);
+                       struct rte_mbuf *mbuf, int *direct,
+                       bool reverse, bool *drop, lcoreid_t *peer_cid);
 
-    int (*conn_expire)(struct dp_vs_proto *proto, 
+    int (*conn_expire)(struct dp_vs_proto *proto,
                        struct dp_vs_conn *conn);
 
     /* for NAT mode */
@@ -85,13 +85,13 @@ struct dp_vs_proto {
     int (*csum_check)(struct dp_vs_proto *proto, int af,
                        struct rte_mbuf *mbuf);
     int (*dump_packet)(struct dp_vs_proto *proto, int af,
-                       struct rte_mbuf *mbuf, int off, 
+                       struct rte_mbuf *mbuf, int off,
                        const char *msg);
 
     /* try trans connn's states by packet and direction */
-    int (*state_trans)(struct dp_vs_proto *proto, 
-                       struct dp_vs_conn *conn, 
-                       struct rte_mbuf *mbuf, 
+    int (*state_trans)(struct dp_vs_proto *proto,
+                       struct dp_vs_conn *conn,
+                       struct rte_mbuf *mbuf,
                        int direct);
 
     const char *

--- a/include/ipvs/redirect.h
+++ b/include/ipvs/redirect.h
@@ -1,0 +1,65 @@
+/*
+ * DPVS is a software load balancer (Virtual Server) based on DPDK.
+ *
+ * Copyright (C) 2017 iQIYI (www.iqiyi.com).
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+#ifndef __DPVS_REDIRECT_H__
+#define __DPVS_REDIRECT_H__
+#include "common.h"
+#include "list.h"
+#include "dpdk.h"
+#include "netif.h"
+#include "ipvs/conn.h"
+#include "ipvs/dest.h"
+
+/*
+ * The conneciton redirect tuple is only for the reverse tuple
+ * (inside -> outside) in nat-mode.
+ */
+struct dp_vs_redirect {
+    struct list_head     list;
+
+    uint8_t              af;
+    uint8_t              proto;
+    lcoreid_t            cid;
+    uint8_t              padding;
+
+    union inet_addr      saddr;
+    union inet_addr      daddr;
+    uint16_t             sport;
+    uint16_t             dport;
+
+    struct rte_mempool  *redirect_pool;
+} __rte_cache_aligned;
+
+struct dp_vs_redirect *dp_vs_redirect_alloc(enum dpvs_fwd_mode fwdmode);
+void dp_vs_redirect_free(struct dp_vs_conn *conn);
+void dp_vs_redirect_init(struct dp_vs_conn *conn);
+struct dp_vs_redirect *dp_vs_redirect_get(int af, uint16_t proto,
+    const union inet_addr *saddr, const union inet_addr *daddr,
+    uint16_t sport, uint16_t dport);
+
+int dp_vs_redirect_hash(struct dp_vs_conn *conn);
+int dp_vs_redirect_unhash(struct dp_vs_conn *conn);
+
+int dp_vs_redirect_table_init(void);
+
+int dp_vs_redirect_pkt(struct rte_mbuf *mbuf, lcoreid_t peer_cid);
+void dp_vs_redirect_ring_proc(struct netif_queue_conf *qconf, lcoreid_t cid);
+
+int dp_vs_redirects_init(void);
+int dp_vs_redirects_term(void);
+
+#endif /* __DPVS_REDIRECT_H__ */

--- a/include/netif.h
+++ b/include/netif.h
@@ -69,7 +69,7 @@ struct rx_partner;
 /* RX/TX queue conf for lcore */
 struct netif_queue_conf
 {
-    queueid_t id; 
+    queueid_t id;
     uint16_t len;
     uint16_t kni_len;
     struct rx_partner *isol_rxq;
@@ -83,7 +83,7 @@ struct netif_queue_conf
  */
 struct netif_port_conf
 {
-    portid_t id; 
+    portid_t id;
     /* rx/tx queues for this lcore to process*/
     int nrxq;
     int ntxq;
@@ -98,7 +98,7 @@ struct netif_port_conf
  */
 struct netif_lcore_conf
 {
-    lcoreid_t id; 
+    lcoreid_t id;
     /* nic number of this lcore to process */
     int nports;
     /* port list of this lcore to process */
@@ -290,7 +290,7 @@ int netif_register_pkt(struct pkt_type *pt);
 int netif_unregister_pkt(struct pkt_type *pt);
 
 /**************************** port API ******************************/
-int netif_fdir_filter_set(struct netif_port *port, enum rte_filter_op opcode, 
+int netif_fdir_filter_set(struct netif_port *port, enum rte_filter_op opcode,
                           const struct rte_eth_fdir_filter *fdir_flt);
 struct netif_port* netif_port_get(portid_t id);
 /* port_conf can be NULL for default port configure */
@@ -362,5 +362,8 @@ static inline char *eth_addr_dump(const struct ether_addr *ea,
 }
 
 portid_t netif_port_count(void);
+
+void lcore_process_packets(struct netif_queue_conf *qconf,
+    struct rte_mbuf **mbufs, lcoreid_t cid, uint16_t count, bool pretetch);
 
 #endif /* __DPVS_NETIF_H__ */

--- a/src/ipvs/ip_vs_proto_udp.c
+++ b/src/ipvs/ip_vs_proto_udp.c
@@ -114,7 +114,7 @@ static struct dp_vs_conn *
 udp_conn_lookup(struct dp_vs_proto *proto,
                 const struct dp_vs_iphdr *iph,
                 struct rte_mbuf *mbuf, int *direct,
-                bool reverse, bool *drop)
+                bool reverse, bool *drop, lcoreid_t *peer_cid)
 {
     struct udp_hdr *uh, _udph;
     struct dp_vs_conn *conn;
@@ -128,11 +128,11 @@ udp_conn_lookup(struct dp_vs_proto *proto,
                             &iph->saddr)) {
         *drop = true;
         return NULL;
-    }  
+    }
 
-    conn = dp_vs_conn_get(iph->af, iph->proto, 
-                          &iph->saddr, &iph->daddr, 
-                          uh->src_port, uh->dst_port, 
+    conn = dp_vs_conn_get(iph->af, iph->proto,
+                          &iph->saddr, &iph->daddr,
+                          uh->src_port, uh->dst_port,
                           direct, reverse);
 
     /*
@@ -141,9 +141,18 @@ udp_conn_lookup(struct dp_vs_proto *proto,
      * UDP can only confirm neighbour to RS
      */
     if (conn != NULL) {
-        if ((*direct == DPVS_CONN_DIR_OUTBOUND) && conn->in_dev 
+        if ((*direct == DPVS_CONN_DIR_OUTBOUND) && conn->in_dev
              && (conn->in_nexthop.in.s_addr != htonl(INADDR_ANY))){
             neigh_confirm(conn->in_nexthop.in, conn->in_dev);
+        }
+    } else {
+        struct dp_vs_redirect *r;
+
+        r = dp_vs_redirect_get(iph->af, iph->proto,
+                               &iph->saddr, &iph->daddr,
+                               uh->src_port, uh->dst_port);
+        if (r) {
+            *peer_cid = r->cid;
         }
     }
 

--- a/src/ipvs/ip_vs_redirect.c
+++ b/src/ipvs/ip_vs_redirect.c
@@ -1,0 +1,341 @@
+/*
+ * DPVS is a software load balancer (Virtual Server) based on DPDK.
+ *
+ * Copyright (C) 2017 iQIYI (www.iqiyi.com).
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+#include "ipvs/redirect.h"
+
+#define DPVS_REDIRECT_RING_SIZE  4096
+
+/* the bucket size of the global connection redirect hash table */
+#define DPVS_CR_TAB_SIZE   DPVS_CONN_TAB_SIZE
+#define DPVS_CR_TAB_MASK   DPVS_CONN_TAB_MASK
+
+static struct list_head   *dp_vs_cr_tab;
+static rte_spinlock_t      dp_vs_cr_lock[DPVS_CR_TAB_SIZE];
+static struct rte_mempool *dp_vs_cr_cache[DPVS_MAX_SOCKET];
+#define this_cr_cache      (dp_vs_cr_cache[rte_socket_id()])
+
+static struct rte_ring    *dp_vs_redirect_ring[DPVS_MAX_LCORE][DPVS_MAX_LCORE];
+
+struct dp_vs_redirect *
+dp_vs_redirect_alloc(enum dpvs_fwd_mode fwdmode)
+{
+    struct dp_vs_redirect *r;
+
+    if (fwdmode != DPVS_FWD_MODE_NAT) {
+        return NULL;
+    }
+
+    if (unlikely(rte_mempool_get(this_cr_cache, (void **)&r) != 0)) {
+        RTE_LOG(WARNING, IPVS,
+                "%s: no memory for conn redirect\n", __func__);
+        return NULL;
+    }
+
+    memset(r, 0, sizeof(struct dp_vs_redirect));
+    r->redirect_pool = this_cr_cache;
+
+    return r;
+}
+
+void dp_vs_redirect_free(struct dp_vs_conn *conn)
+{
+    if (conn->redirect) {
+        rte_mempool_put(this_cr_cache, conn->redirect);
+        conn->redirect = NULL;
+    }
+}
+
+void dp_vs_redirect_init(struct dp_vs_conn *conn)
+{
+    struct conn_tuple_hash *t = &tuplehash_out(conn);
+    struct dp_vs_redirect *r = conn->redirect;
+
+    r->af    = t->af;
+    r->proto = t->proto;
+    r->saddr = t->saddr;
+    r->daddr = t->daddr;
+    r->sport = t->sport;
+    r->dport = t->dport;
+    r->cid   = rte_lcore_id();
+}
+
+/**
+ * try lookup dp_vs_cr_tab{} by packet tuple
+ *
+ *  <af, proto, saddr, sport, daddr, dport>.
+ *
+ * return r if found or NULL if not exist.
+ */
+struct dp_vs_redirect *
+dp_vs_redirect_get(int af, uint16_t proto,
+    const union inet_addr *saddr, const union inet_addr *daddr,
+    uint16_t sport, uint16_t dport)
+{
+    uint32_t hash;
+    struct dp_vs_redirect *r;
+#ifdef CONFIG_DPVS_IPVS_DEBUG
+    char sbuf[64], dbuf[64];
+#endif
+
+    hash = dp_vs_conn_hashkey(af, saddr, sport, daddr, dport, DPVS_CR_TAB_MASK);
+
+    rte_spinlock_lock(&dp_vs_cr_lock[hash]);
+    list_for_each_entry(r, &dp_vs_cr_tab[hash], list) {
+        if (r->af == af
+            && r->proto == proto
+            && r->sport == sport
+            && r->dport == dport
+            && inet_addr_equal(af, &r->saddr, saddr)
+            && inet_addr_equal(af, &r->daddr, daddr))
+        {
+            goto found;
+        }
+    }
+    rte_spinlock_unlock(&dp_vs_cr_lock[hash]);
+
+    return NULL;
+
+found:
+    rte_spinlock_unlock(&dp_vs_cr_lock[hash]);
+
+#ifdef CONFIG_DPVS_IPVS_DEBUG
+    RTE_LOG(DEBUG, IPVS, "redirect lookup: [%d -> %d] %s %s:%d -> %s:%d %s \n",
+            rte_lcore_id(), r->cid, inet_proto_name(proto),
+            inet_ntop(af, saddr, sbuf, sizeof(sbuf)) ? sbuf : "::", ntohs(sport),
+            inet_ntop(af, daddr, dbuf, sizeof(dbuf)) ? dbuf : "::", ntohs(dport),
+            r ? "hit" : "miss");
+#endif
+
+    return r;
+}
+
+int dp_vs_redirect_hash(struct dp_vs_conn *conn)
+{
+    uint32_t hash;
+    struct dp_vs_redirect *r = conn->redirect;
+
+    if (unlikely(dp_vs_conn_is_redirect_hashed(conn))) {
+        return EDPVS_EXIST;
+    }
+
+    hash = dp_vs_conn_hashkey(conn->af,
+                    &tuplehash_out(conn).saddr, tuplehash_out(conn).sport,
+                    &tuplehash_out(conn).daddr, tuplehash_out(conn).dport,
+                    DPVS_CR_TAB_MASK);
+
+    rte_spinlock_lock(&dp_vs_cr_lock[hash]);
+    list_add(&r->list, &dp_vs_cr_tab[hash]);
+    rte_spinlock_unlock(&dp_vs_cr_lock[hash]);
+
+    dp_vs_conn_set_redirect_hashed(conn);
+
+    return EDPVS_OK;
+}
+
+int dp_vs_redirect_unhash(struct dp_vs_conn *conn)
+{
+    int err;
+    uint32_t hash;
+    struct dp_vs_redirect *r = conn->redirect;
+
+    if (likely(dp_vs_conn_is_redirect_hashed(conn))) {
+        hash = dp_vs_conn_hashkey(r->af,
+                                  &r->saddr, r->sport,
+                                  &r->daddr, r->dport,
+                                  DPVS_CR_TAB_MASK);
+
+        rte_spinlock_lock(&dp_vs_cr_lock[hash]);
+        list_del(&r->list);
+        rte_spinlock_unlock(&dp_vs_cr_lock[hash]);
+
+        dp_vs_conn_clear_redirect_hashed(conn);
+        err = EDPVS_OK;
+    } else {
+        err = EDPVS_NOTEXIST;
+    }
+
+    return err;
+}
+
+/**
+ * Forward the packet to the found redirect owner core.
+ */
+int dp_vs_redirect_pkt(struct rte_mbuf *mbuf, lcoreid_t peer_cid)
+{
+    lcoreid_t cid = rte_lcore_id();
+    int ret;
+
+    ret = rte_ring_enqueue(dp_vs_redirect_ring[peer_cid][cid], mbuf);
+    if (ret < 0) {
+        RTE_LOG(WARNING, IPVS,
+                "%s: [%d] failed to enqueue mbuf to redirect_ring[%d][%d]\n",
+                __func__, cid, peer_cid, cid);
+        return INET_DROP;
+    }
+
+    return INET_STOLEN;
+}
+
+void dp_vs_redirect_ring_proc(struct netif_queue_conf *qconf, lcoreid_t cid)
+{
+    struct rte_mbuf *mbufs[NETIF_MAX_PKT_BURST];
+    uint16_t nb_rb;
+    lcoreid_t peer_cid;
+
+    cid = rte_lcore_id();
+
+    for (peer_cid = 0; peer_cid < DPVS_MAX_LCORE; peer_cid++) {
+        if (dp_vs_redirect_ring[cid][peer_cid]) {
+            nb_rb = rte_ring_dequeue_burst(dp_vs_redirect_ring[cid][peer_cid],
+                                           (void**)mbufs,
+                                           NETIF_MAX_PKT_BURST, NULL);
+            if (nb_rb > 0) {
+                lcore_process_packets(qconf, mbufs, cid, nb_rb, 0);
+            }
+        }
+    }
+}
+
+static int dp_vs_redirect_table_create(void)
+{
+    int i;
+    char poolname[32];
+
+    /*
+     * allocate redirect cache on each NUMA socket and its size is
+     * same as conn_pool_size
+     */
+    for (i = 0; i < get_numa_nodes(); i++) {
+        snprintf(poolname, sizeof(poolname), "dp_vs_redirect_%d", i);
+        dp_vs_cr_cache[i] =
+            rte_mempool_create(poolname,
+                               dp_vs_conn_pool_size(),
+                               sizeof(struct dp_vs_redirect),
+                               dp_vs_conn_pool_cache_size(),
+                               0, NULL, NULL, NULL, NULL,
+                               i, 0);
+        if (!dp_vs_cr_cache[i]) {
+            return EDPVS_NOMEM;
+        }
+    }
+
+    /* allocate the global redirect hash table, per socket? */
+    dp_vs_cr_tab =
+        rte_malloc_socket(NULL, sizeof(struct list_head ) * DPVS_CR_TAB_SIZE,
+                          RTE_CACHE_LINE_SIZE, rte_socket_id());
+    if (!dp_vs_cr_tab) {
+        return EDPVS_NOMEM;
+    }
+
+    /* init the global redirect hash table */
+    for (i = 0; i < DPVS_CR_TAB_SIZE; i++) {
+        INIT_LIST_HEAD(&dp_vs_cr_tab[i]);
+        rte_spinlock_init(&dp_vs_cr_lock[i]);
+    }
+
+    return EDPVS_OK;
+}
+
+static void dp_vs_redirect_table_free(void)
+{
+    int i;
+
+    for (i = 0; i < get_numa_nodes(); i++) {
+        rte_mempool_free(dp_vs_cr_cache[i]);
+    }
+
+    /* release the global redirect hash table */
+    rte_free(dp_vs_cr_tab);
+}
+
+/*
+ * Each lcore allocates redirect rings with the other lcores espectively.
+ */
+static int dp_vs_redirect_ring_create(void)
+{
+    char name_buf[RTE_RING_NAMESIZE];
+    int socket_id;
+    lcoreid_t cid, peer_cid;
+
+    socket_id = rte_socket_id();
+
+    for (cid = 0; cid < DPVS_MAX_LCORE; cid++) {
+        if (cid == rte_get_master_lcore() || !rte_lcore_is_enabled(cid)) {
+            continue;
+        }
+
+        for (peer_cid = 0; peer_cid < DPVS_MAX_LCORE; peer_cid++) {
+            if (!rte_lcore_is_enabled(peer_cid)
+                || peer_cid == rte_get_master_lcore()
+                || cid == peer_cid)
+            {
+                continue;
+            }
+
+            snprintf(name_buf, RTE_RING_NAMESIZE,
+                     "dp_vs_redirect_ring[%d[%d]", cid, peer_cid);
+
+            dp_vs_redirect_ring[cid][peer_cid] =
+                rte_ring_create(name_buf, DPVS_REDIRECT_RING_SIZE, socket_id,
+                                RING_F_SP_ENQ | RING_F_SC_DEQ);
+
+            if (!dp_vs_redirect_ring[cid][peer_cid]) {
+                RTE_LOG(WARNING, IPVS,
+                        "%s: failed to create redirect_ring[%d][%d]\n",
+                        __func__, cid, peer_cid);
+                return EDPVS_NOMEM;
+            } else {
+                RTE_LOG(WARNING, IPVS,
+                        "%s: created redirect_ring[%d][%d]\n",
+                        __func__, cid, peer_cid);
+            }
+        }
+    }
+
+    return EDPVS_OK;
+}
+
+static void dp_vs_redirect_ring_free(void)
+{
+    lcoreid_t cid, peer_cid;
+
+    for (cid = 0; cid < DPVS_MAX_LCORE; cid++) {
+        for (peer_cid = 0; peer_cid < DPVS_MAX_LCORE; peer_cid++) {
+            rte_ring_free(dp_vs_redirect_ring[cid][peer_cid]);
+        }
+    }
+}
+
+int dp_vs_redirects_init(void)
+{
+    int err;
+
+    err = dp_vs_redirect_ring_create();
+    if (err != EDPVS_OK) {
+        return err;
+    }
+
+    return dp_vs_redirect_table_create();
+}
+
+int dp_vs_redirects_term(void)
+{
+    dp_vs_redirect_ring_free();
+    dp_vs_redirect_table_free();
+
+    return EDPVS_OK;
+}

--- a/src/netif.c
+++ b/src/netif.c
@@ -41,7 +41,7 @@
 #include <rte_arp.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-
+#include <ipvs/redirect.h>
 
 #define NETIF_PKTPOOL_NB_MBUF_DEF   65535
 #define NETIF_PKTPOOL_NB_MBUF_MIN   1023
@@ -313,7 +313,7 @@ static void rss_handler(vector_t tokens)
             struct port_conf_stream, port_list_node);
 
     assert(str);
-    if (!strcmp(str, "all") || !strcmp(str, "ip") || !strcmp(str, "tcp") || !strcmp(str, "udp") 
+    if (!strcmp(str, "all") || !strcmp(str, "ip") || !strcmp(str, "tcp") || !strcmp(str, "udp")
             || !strcmp(str, "sctp") || !strcmp(str, "ether") || !strcmp(str, "port") || !strcmp(str, "tunnel")) {
         RTE_LOG(INFO, NETIF, "%s:rss = %s\n", current_device->name, str);
         strncpy(current_device->rss, str, sizeof(current_device->rss));
@@ -952,7 +952,7 @@ static struct pkt_type *pkt_type_get(uint16_t type, struct netif_port *port)
 }
 
 /****************************************** lcore job *********************************************/
-/* Note: lockless, lcore_job can only be register on initialization stage and 
+/* Note: lockless, lcore_job can only be register on initialization stage and
  *       unregistered on cleanup stage.
  */
 struct list_head netif_lcore_jobs[NETIF_LCORE_JOB_TYPE_MAX];
@@ -2000,7 +2000,7 @@ int netif_hard_xmit(struct rte_mbuf *mbuf, struct netif_port *dev)
         (lcore_conf[lcore2index[cid]].pqs[port2index[cid][pid]].ntxq);
     //RTE_LOG(DEBUG, NETIF, "tx-queue hash(%x) = %d\n", ((uint32_t)mbuf->buf_physaddr) >> 8, qindex);
     txq = &lcore_conf[lcore2index[cid]].pqs[port2index[cid][pid]].txqs[qindex];
-    
+
     if (unlikely(txq->len == NETIF_MAX_PKT_BURST)) {
         netif_tx_burst(cid, pid, qindex);
         txq->len = 0;
@@ -2051,7 +2051,7 @@ static inline eth_type_t eth_type_parse(const struct ether_hdr *eth_hdr,
         else
             return ETH_PKT_MULTICAST;
     }
-    
+
     return ETH_PKT_OTHERHOST;
 }
 
@@ -2177,7 +2177,7 @@ static int netif_arp_ring_init(void)
     return EDPVS_OK;
 }
 
-static void lcore_process_packets(struct netif_queue_conf *qconf, struct rte_mbuf **mbufs,
+void lcore_process_packets(struct netif_queue_conf *qconf, struct rte_mbuf **mbufs,
                       lcoreid_t cid, uint16_t count, bool pkts_from_ring)
 {
     int i, t;
@@ -2280,6 +2280,11 @@ static void lcore_process_arp_ring(struct netif_queue_conf *qconf, lcoreid_t cid
     }
 }
 
+static void lcore_process_redirect_ring(struct netif_queue_conf *qconf, lcoreid_t cid)
+{
+    dp_vs_redirect_ring_proc(qconf, cid);
+}
+
 static void lcore_job_recv_fwd(void *arg)
 {
     int i, j;
@@ -2298,6 +2303,7 @@ static void lcore_job_recv_fwd(void *arg)
             qconf = &lcore_conf[lcore2index[cid]].pqs[i].rxqs[j];
 
             lcore_process_arp_ring(qconf, cid);
+            lcore_process_redirect_ring(qconf, cid);
             qconf->len = netif_rx_burst(pid, qconf);
 
             lcore_stats_burst(&lcore_stats[cid], qconf->len);
@@ -2396,7 +2402,7 @@ static void netif_lcore_init(void)
     for (ii = 0; ii < NETIF_JOB_COUNT; ii++) {
         res = netif_lcore_loop_job_register(&netif_jobs[ii]);
         if (res < 0) {
-            rte_exit(EXIT_FAILURE, 
+            rte_exit(EXIT_FAILURE,
                     "[%s] Fail to register netif lcore jobs, exiting ...\n", __func__);
             break;
         }
@@ -2442,10 +2448,10 @@ static inline void free_mbufs(struct rte_mbuf **pkts, unsigned num)
     for (i = 0; i < num; i++) {
         rte_pktmbuf_free(pkts[i]);
         pkts[i] = NULL;
-    }    
+    }
 }
 
-static void kni_ingress(struct rte_mbuf *mbuf, struct netif_port *dev, 
+static void kni_ingress(struct rte_mbuf *mbuf, struct netif_port *dev,
                         struct netif_queue_conf *qconf)
 {
     unsigned pkt_num;
@@ -2482,7 +2488,7 @@ static void kni_send2kern_loop(uint8_t port_id, struct netif_queue_conf *qconf)
 {
     struct netif_port *dev;
     unsigned pkt_num;
-   
+
     dev = netif_port_get(port_id);
 
     if (qconf->kni_len > 0) {
@@ -2884,7 +2890,7 @@ static struct netif_port* netif_rte_port_alloc(portid_t id, int nrxq,
     port->hw_header_len = sizeof(struct ether_hdr);
     if (port->socket == SOCKET_ID_ANY)
         port->socket = rte_socket_id();
-    port->mbuf_pool = pktmbuf_pool[port->socket]; 
+    port->mbuf_pool = pktmbuf_pool[port->socket];
     rte_eth_macaddr_get((uint8_t)id, &port->addr);
     rte_eth_dev_get_mtu((uint8_t)id, &port->mtu);
     rte_eth_dev_info_get((uint8_t)id, &port->dev_info);
@@ -2969,7 +2975,7 @@ int netif_get_queue(struct netif_port *port, lcoreid_t cid, queueid_t *qid)
     if (++idx > IDX_MAX)
         idx = 0;
 
-    *qid = qconf->rxqs[idx % qconf->nrxq].id; 
+    *qid = qconf->rxqs[idx % qconf->nrxq].id;
     return EDPVS_OK;
 }
 
@@ -3010,7 +3016,7 @@ int netif_get_stats(struct netif_port *dev, struct rte_eth_stats *stats)
     return EDPVS_OK;
 }
 
-int netif_fdir_filter_set(struct netif_port *port, enum rte_filter_op opcode, 
+int netif_fdir_filter_set(struct netif_port *port, enum rte_filter_op opcode,
                           const struct rte_eth_fdir_filter *fdir_flt)
 {
     assert(port && port->netif_ops);
@@ -3288,7 +3294,7 @@ int netif_port_start(struct netif_port *port)
     if (port->ntxq > 0) {
         for (qid = 0; qid < port->ntxq; qid++) {
             memcpy(&txconf, &port->dev_info.default_txconf, sizeof(struct rte_eth_txconf));
-            if (port->dev_conf.rxmode.jumbo_frame 
+            if (port->dev_conf.rxmode.jumbo_frame
                     || (port->flag & NETIF_PORT_FLAG_TX_IP_CSUM_OFFLOAD)
                     || (port->flag & NETIF_PORT_FLAG_TX_UDP_CSUM_OFFLOAD)
                     || (port->flag & NETIF_PORT_FLAG_TX_TCP_CSUM_OFFLOAD))
@@ -3316,20 +3322,20 @@ int netif_port_start(struct netif_port *port)
     // build port-queue-lcore mapping array
     build_port_queue_lcore_map();
 
-    // start the device 
+    // start the device
     ret = rte_eth_dev_start(port->id);
     if (ret < 0) {
         RTE_LOG(ERR, NETIF, "%s: fail to start %s\n", __func__, port->name);
         return EDPVS_DPDKAPIFAIL;
     }
 
-    // wait the device link up 
+    // wait the device link up
     RTE_LOG(INFO, NETIF, "Waiting for %s link up, be patient ...\n", port->name);
     for (ii = 0; ii < wait_link_up_msecs; ii++) {
         rte_eth_link_get_nowait(port->id, &link);
         if (link.link_status) {
             RTE_LOG(INFO, NETIF, ">> %s: link up - speed %u Mbps - %s\n",
-                    port->name, (unsigned)link.link_speed, 
+                    port->name, (unsigned)link.link_speed,
                     (link.link_duplex == ETH_LINK_FULL_DUPLEX) ?
                     "full-duplex" : "half-duplex");
             break;


### PR DESCRIPTION
During the system boots up, the below resource is pre-allcoated.

- Per-socket based connection redirect cache;
- Per-socket based global connection redirect hash table;
- Each lcore allocates the respective packet redirect rings for each other
  lcores to avoid the contention of enqueuing the packets in the same ring.

o When a connection is created and hashed in nat-mode, the related redirect
  is allocated and hashed accordingly.

o When a connection expires to be unhashed and freed in nat-mode, the related
  redirect is unhashed and freed accordingly.

o In the stage of PRE_ROUTING, if the packet does not match any dpvs connection,
  then check if it matches any connection redirect entry. If matched, enqueue
  the packet into the packet redirect ring of the rediret owner core; otherwise,
  continue to process it on the current lcore.

o Within lcore_job_recv_fwd(), add the task of dequeuing the packets from all
  the packet redirect rings owned by the current lcore and process them
  accordingly.