### PR TITLE
set errorno after pthread_get/setaffinity_np fails

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -56,6 +56,7 @@ static int set_all_thread_affinity(void)
 
     s = pthread_setaffinity_np(tid, sizeof(cpu_set_t), &cpuset);
     if (s != 0) {
+        errno = s;
         perror("fail to set thread affinty");
         return -1;
     }
@@ -63,6 +64,7 @@ static int set_all_thread_affinity(void)
     CPU_ZERO(&cpuset);
     s = pthread_getaffinity_np(tid, sizeof(cpu_set_t), &cpuset);
     if (s != 0) {
+        errno = s;
         perror("fail to get thread affinity");
         return -2;
     }


### PR DESCRIPTION
the return value of pthread_getaffinity_np and pthread_setaffinity_np must be set to the variable errno to describe what went wrong.