### PR TITLE
ipvs: add connection redirect support in fnat/snat/nat modes.

### DIFF
--- a/include/conf/netif.h
+++ b/include/conf/netif.h
@@ -278,4 +278,6 @@ typedef struct netif_bond_set {
     } opt;
 } netif_bond_set_t;
 
+void lcore_process_packets(struct netif_queue_conf *qconf, struct rte_mbuf **mbufs,
+                           lcoreid_t cid, uint16_t count, bool pkts_from_ring);
 #endif

--- a/include/ipvs/conn.h
+++ b/include/ipvs/conn.h
@@ -27,6 +27,7 @@
 #include "ipvs/conn.h"
 #include "ipvs/proto.h"
 #include "ipvs/service.h"
+#include "ipvs/redirect.h"
 
 enum {
     DPVS_CONN_DIR_INBOUND = 0,
@@ -35,11 +36,12 @@ enum {
 };
 
 enum {
-    DPVS_CONN_F_HASHED      = 0x0040,
-    DPVS_CONN_F_INACTIVE    = 0x0100,
-    DPVS_CONN_F_SYNPROXY    = 0x8000,
-    DPVS_CONN_F_TEMPLATE    = 0x1000,
-    DPVS_CONN_F_NOFASTXMIT  = 0x2000,
+    DPVS_CONN_F_HASHED          = 0x0040,
+    DPVS_CONN_F_REDIRECT_HASHED = 0x0080,
+    DPVS_CONN_F_INACTIVE        = 0x0100,
+    DPVS_CONN_F_SYNPROXY        = 0x8000,
+    DPVS_CONN_F_TEMPLATE        = 0x1000,
+    DPVS_CONN_F_NOFASTXMIT      = 0x2000,
 };
 
 struct dp_vs_conn_param {
@@ -147,6 +149,9 @@ struct dp_vs_conn {
     struct dp_vs_conn *control;         /* master who controlls me */
     rte_atomic32_t n_control;           /* number of connections controlled by me*/
     uint64_t ctime;                     /* create time */
+
+    /* connection redirect in fnat/snat/nat modes */
+    struct dp_vs_redirect  *redirect;
 } __rte_cache_aligned;
 
 /* for syn-proxy to save all ack packet in conn before rs's syn-ack arrives */
@@ -162,8 +167,8 @@ struct dp_vs_synproxy_ack_pakcet {
 int dp_vs_conn_init(void);
 int dp_vs_conn_term(void);
 
-struct dp_vs_conn * 
-dp_vs_conn_new(struct rte_mbuf *mbuf, 
+struct dp_vs_conn *
+dp_vs_conn_new(struct rte_mbuf *mbuf,
                const struct dp_vs_iphdr *iph,
                struct dp_vs_conn_param *param,
                struct dp_vs_dest *dest,
@@ -171,9 +176,9 @@ dp_vs_conn_new(struct rte_mbuf *mbuf,
 int dp_vs_conn_del(struct dp_vs_conn *conn);
 
 struct dp_vs_conn *
-dp_vs_conn_get(int af, uint16_t proto, 
-                const union inet_addr *saddr, 
-                const union inet_addr *daddr, 
+dp_vs_conn_get(int af, uint16_t proto,
+                const union inet_addr *saddr,
+                const union inet_addr *daddr,
                 uint16_t sport, uint16_t dport,
                 int *dir, bool reverse);
 
@@ -190,8 +195,8 @@ void dp_vs_conn_put_no_reset(struct dp_vs_conn *conn);
 void ipvs_conn_keyword_value_init(void);
 void install_ipvs_conn_keywords(void);
 
-static inline void dp_vs_conn_fill_param(int af, uint8_t proto, 
-        const union inet_addr *caddr, const union inet_addr *vaddr, 
+static inline void dp_vs_conn_fill_param(int af, uint8_t proto,
+        const union inet_addr *caddr, const union inet_addr *vaddr,
         uint16_t cport, uint16_t vport, uint16_t ct_dport,
         struct dp_vs_conn_param *param)
 {
@@ -269,5 +274,30 @@ static inline void dp_vs_control_add(struct dp_vs_conn *conn, struct dp_vs_conn 
     conn->control = ctl_conn;
     rte_atomic32_inc(&ctl_conn->n_control);
 }
+
+static inline bool
+dp_vs_conn_is_redirect_hashed(struct dp_vs_conn *conn)
+{
+    return  (conn->flags & DPVS_CONN_F_REDIRECT_HASHED) ? true : false;
+}
+
+static inline void
+dp_vs_conn_set_redirect_hashed(struct dp_vs_conn *conn)
+{
+    conn->flags |= DPVS_CONN_F_REDIRECT_HASHED;
+}
+
+static inline void
+dp_vs_conn_clear_redirect_hashed(struct dp_vs_conn *conn)
+{
+    conn->flags &= ~DPVS_CONN_F_REDIRECT_HASHED;
+}
+
+uint32_t dp_vs_conn_hashkey(int af,
+    const union inet_addr *saddr, uint16_t sport,
+    const union inet_addr *daddr, uint16_t dport,
+    uint32_t mask);
+int dp_vs_conn_pool_size(void);
+int dp_vs_conn_pool_cache_size(void);
 
 #endif /* __DPVS_CONN_H__ */

--- a/include/ipvs/proto.h
+++ b/include/ipvs/proto.h
@@ -36,7 +36,7 @@ struct dp_vs_proto {
     int (*exit)(struct dp_vs_proto *proto);
 
     /* schedule RS and create new conn */
-    int (*conn_sched)(struct dp_vs_proto *proto, 
+    int (*conn_sched)(struct dp_vs_proto *proto,
                       const struct dp_vs_iphdr *iph,
                       struct rte_mbuf *mbuf,
                       struct dp_vs_conn **conn,
@@ -45,12 +45,12 @@ struct dp_vs_proto {
     /* lookup conn by <proto, saddr, sport, daddr, dport>
      * return conn and direction or NULL if miss */
     struct dp_vs_conn *
-        (*conn_lookup)(struct dp_vs_proto *proto, 
+        (*conn_lookup)(struct dp_vs_proto *proto,
                        const struct dp_vs_iphdr *iph,
-                       struct rte_mbuf *mbuf, int *direct, 
-                       bool reverse, bool *drop);
+                       struct rte_mbuf *mbuf, int *direct,
+                       bool reverse, bool *drop, lcoreid_t *peer_cid);
 
-    int (*conn_expire)(struct dp_vs_proto *proto, 
+    int (*conn_expire)(struct dp_vs_proto *proto,
                        struct dp_vs_conn *conn);
 
     /* for NAT mode */
@@ -87,13 +87,13 @@ struct dp_vs_proto {
     int (*csum_check)(struct dp_vs_proto *proto, int af,
                        struct rte_mbuf *mbuf);
     int (*dump_packet)(struct dp_vs_proto *proto, int af,
-                       struct rte_mbuf *mbuf, int off, 
+                       struct rte_mbuf *mbuf, int off,
                        const char *msg);
 
     /* try trans connn's states by packet and direction */
-    int (*state_trans)(struct dp_vs_proto *proto, 
-                       struct dp_vs_conn *conn, 
-                       struct rte_mbuf *mbuf, 
+    int (*state_trans)(struct dp_vs_proto *proto,
+                       struct dp_vs_conn *conn,
+                       struct rte_mbuf *mbuf,
                        int direct);
 
     const char *

--- a/include/ipvs/redirect.h
+++ b/include/ipvs/redirect.h
@@ -1,0 +1,61 @@
+/*
+ * DPVS is a software load balancer (Virtual Server) based on DPDK.
+ *
+ * Copyright (C) 2017 iQIYI (www.iqiyi.com).
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+#ifndef __DPVS_REDIRECT_H__
+#define __DPVS_REDIRECT_H__
+#include "common.h"
+#include "list.h"
+#include "dpdk.h"
+#include "netif.h"
+#include "ipvs/conn.h"
+#include "ipvs/dest.h"
+
+/*
+ * The conneciton redirect tuple is only for the reverse tuple
+ * (inside -> outside) in nat-mode.
+ */
+struct dp_vs_redirect {
+    struct list_head     list;
+
+    uint8_t              af;
+    uint8_t              proto;
+    lcoreid_t            cid;
+    uint8_t              padding;
+
+    union inet_addr      saddr;
+    union inet_addr      daddr;
+    uint16_t             sport;
+    uint16_t             dport;
+
+    struct rte_mempool  *redirect_pool;
+} __rte_cache_aligned;
+
+struct dp_vs_redirect *dp_vs_redirect_alloc(enum dpvs_fwd_mode fwdmode);
+void dp_vs_redirect_free(struct dp_vs_conn *conn);
+void dp_vs_redirect_hash(struct dp_vs_conn *conn);
+void dp_vs_redirect_unhash(struct dp_vs_conn *conn);
+struct dp_vs_redirect *dp_vs_redirect_get(int af, uint16_t proto,
+    const union inet_addr *saddr, const union inet_addr *daddr,
+    uint16_t sport, uint16_t dport);
+void dp_vs_redirect_init(struct dp_vs_conn *conn);
+int dp_vs_redirect_table_init(void);
+int dp_vs_redirect_pkt(struct rte_mbuf *mbuf, lcoreid_t peer_cid);
+void dp_vs_redirect_ring_proc(struct netif_queue_conf *qconf, lcoreid_t cid);
+int dp_vs_redirects_init(void);
+int dp_vs_redirects_term(void);
+
+#endif /* __DPVS_REDIRECT_H__ */

--- a/include/netif.h
+++ b/include/netif.h
@@ -70,7 +70,7 @@ struct rx_partner;
 /* RX/TX queue conf for lcore */
 struct netif_queue_conf
 {
-    queueid_t id; 
+    queueid_t id;
     uint16_t len;
     uint16_t kni_len;
     struct rx_partner *isol_rxq;
@@ -84,7 +84,7 @@ struct netif_queue_conf
  */
 struct netif_port_conf
 {
-    portid_t id; 
+    portid_t id;
     /* rx/tx queues for this lcore to process*/
     int nrxq;
     int ntxq;
@@ -99,7 +99,7 @@ struct netif_port_conf
  */
 struct netif_lcore_conf
 {
-    lcoreid_t id; 
+    lcoreid_t id;
     /* nic number of this lcore to process */
     int nports;
     /* port list of this lcore to process */
@@ -283,13 +283,14 @@ int netif_lcore_loop_job_register(struct netif_lcore_loop_job *lcore_job);
 int netif_lcore_loop_job_unregister(struct netif_lcore_loop_job *lcore_job);
 int netif_lcore_start(void);
 bool is_lcore_id_valid(lcoreid_t cid);
+bool netif_lcore_is_idle(lcoreid_t cid);
 
 /************************** protocol API *****************************/
 int netif_register_pkt(struct pkt_type *pt);
 int netif_unregister_pkt(struct pkt_type *pt);
 
 /**************************** port API ******************************/
-int netif_fdir_filter_set(struct netif_port *port, enum rte_filter_op opcode, 
+int netif_fdir_filter_set(struct netif_port *port, enum rte_filter_op opcode,
                           const struct rte_eth_fdir_filter *fdir_flt);
 void netif_mask_fdir_filter(int af, const struct netif_port *port,
                             struct rte_eth_fdir_filter *filt);
@@ -363,5 +364,7 @@ static inline char *eth_addr_dump(const struct ether_addr *ea,
 }
 
 portid_t netif_port_count(void);
+void lcore_process_packets(struct netif_queue_conf *qconf, struct rte_mbuf **mbufs,
+                           lcoreid_t cid, uint16_t count, bool pkts_from_ring);
 
 #endif /* __DPVS_NETIF_H__ */

--- a/src/ipvs/ip_vs_conn.c
+++ b/src/ipvs/ip_vs_conn.c
@@ -36,27 +36,28 @@
 #include "conf/conn.h"
 #include "sys_time.h"
 
-#define DPVS_CONN_TAB_BITS      20
-#define DPVS_CONN_TAB_SIZE      (1 << DPVS_CONN_TAB_BITS)
-#define DPVS_CONN_TAB_MASK      (DPVS_CONN_TAB_SIZE - 1)
+#define DPVS_CONN_TBL_BITS          20
+#define DPVS_CONN_TBL_SIZE          (1 << DPVS_CONN_TBL_BITS)
+#define DPVS_CONN_TBL_MASK          (DPVS_CONN_TBL_SIZE - 1)
 
 /* too big ? adjust according to free mem ?*/
 #define DPVS_CONN_POOL_SIZE_DEF     2097152
 #define DPVS_CONN_POOL_SIZE_MIN     65536
-static int conn_pool_size = DPVS_CONN_POOL_SIZE_DEF;
 #define DPVS_CONN_CACHE_SIZE_DEF    256
+
+static int conn_pool_size  = DPVS_CONN_POOL_SIZE_DEF;
 static int conn_pool_cache = DPVS_CONN_CACHE_SIZE_DEF;
 
 #define DPVS_CONN_INIT_TIMEOUT_DEF  3   /* sec */
 static int conn_init_timeout = DPVS_CONN_INIT_TIMEOUT_DEF;
 
 /* helpers */
-#define this_conn_tab           (RTE_PER_LCORE(dp_vs_conn_tab))
+#define this_conn_tbl               (RTE_PER_LCORE(dp_vs_conn_tbl))
 #ifdef CONFIG_DPVS_IPVS_CONN_LOCK
-#define this_conn_lock          (RTE_PER_LCORE(dp_vs_conn_lock))
+#define this_conn_lock              (RTE_PER_LCORE(dp_vs_conn_lock))
 #endif
-#define this_conn_count         (RTE_PER_LCORE(dp_vs_conn_count))
-#define this_conn_cache         (dp_vs_conn_cache[rte_socket_id()])
+#define this_conn_count             (RTE_PER_LCORE(dp_vs_conn_count))
+#define this_conn_cache             (dp_vs_conn_cache[rte_socket_id()])
 
 /* dpvs control variables */
 static bool conn_expire_quiescent_template = false;
@@ -64,13 +65,13 @@ static bool conn_expire_quiescent_template = false;
 /*
  * per-lcore dp_vs_conn{} hash table.
  */
-static RTE_DEFINE_PER_LCORE(struct list_head *, dp_vs_conn_tab);
+static RTE_DEFINE_PER_LCORE(struct list_head *, dp_vs_conn_tbl);
 #ifdef CONFIG_DPVS_IPVS_CONN_LOCK
 static RTE_DEFINE_PER_LCORE(rte_spinlock_t, dp_vs_conn_lock);
 #endif
 
 /* global connection template table */
-static struct list_head *dp_vs_ct_tab;
+static struct list_head *dp_vs_ct_tbl;
 static rte_spinlock_t dp_vs_ct_lock;
 
 static RTE_DEFINE_PER_LCORE(uint32_t, dp_vs_conn_count);
@@ -82,6 +83,33 @@ static uint32_t dp_vs_conn_rnd; /* hash random */
  */
 static struct rte_mempool *dp_vs_conn_cache[DPVS_MAX_SOCKET];
 
+static struct dp_vs_conn *dp_vs_conn_alloc(void)
+{
+    struct dp_vs_conn *conn;
+
+    if (unlikely(rte_mempool_get(this_conn_cache, (void **)&conn) != 0)) {
+        RTE_LOG(ERR, IPVS, "%s: no memory\n", __func__);
+        return NULL;
+    }
+
+    memset(conn, 0, sizeof(struct dp_vs_conn));
+    conn->connpool = this_conn_cache;
+    this_conn_count++;
+
+    return conn;
+}
+
+static void dp_vs_conn_free(struct dp_vs_conn *conn)
+{
+    if (!conn)
+        return;
+
+    dp_vs_redirect_free(conn);
+
+    rte_mempool_put(conn->connpool, conn);
+    this_conn_count--;
+}
+
 static inline struct dp_vs_conn *
 tuplehash_to_conn(const struct conn_tuple_hash *thash)
 {
@@ -90,41 +118,75 @@ tuplehash_to_conn(const struct conn_tuple_hash *thash)
 
 static inline uint32_t conn_hashkey(int af,
                                 const union inet_addr *saddr, uint16_t sport,
-                                const union inet_addr *daddr, uint16_t dport)
+                                const union inet_addr *daddr, uint16_t dport,
+                                uint32_t mask)
 {
-    if (AF_INET == af)
+    switch (af) {
+    case AF_INET:
         return rte_jhash_3words((uint32_t)saddr->in.s_addr,
                 (uint32_t)daddr->in.s_addr,
                 ((uint32_t)sport) << 16 | (uint32_t)dport,
-                dp_vs_conn_rnd) & DPVS_CONN_TAB_MASK;
+                dp_vs_conn_rnd) & mask;
 
-    if (AF_INET6 == af) {
-        uint32_t vect[9];
-        vect[0] = ((uint32_t)sport) << 16 | (uint32_t)dport;
-        memcpy(&vect[1], &saddr->in6, 16);
-        memcpy(&vect[5], &daddr->in6, 16);
-        return rte_jhash_32b(vect, 9, dp_vs_conn_rnd) & DPVS_CONN_TAB_MASK;
+    case AF_INET6:
+        {
+            uint32_t vect[9];
+
+            vect[0] = ((uint32_t)sport) << 16 | (uint32_t)dport;
+            memcpy(&vect[1], &saddr->in6, 16);
+            memcpy(&vect[5], &daddr->in6, 16);
+
+            return rte_jhash_32b(vect, 9, dp_vs_conn_rnd) & mask;
+        }
+
+    default:
+        RTE_LOG(WARNING, IPVS, "%s: hashing unsupported protocol %d\n", __func__, af);
+        return 0;
     }
-
-    RTE_LOG(WARNING, IPVS, "%s: hashing unsupported protocol %d\n", __func__, af);
-    return 0;
 }
 
-static inline int __conn_hash(struct dp_vs_conn *conn,
-                              uint32_t ihash, uint32_t ohash)
+uint32_t dp_vs_conn_hashkey(int af,
+    const union inet_addr *saddr, uint16_t sport,
+    const union inet_addr *daddr, uint16_t dport,
+    uint32_t mask)
 {
+    return conn_hashkey(af, saddr, sport, daddr, dport, mask);
+}
+
+static inline int __conn_hash(struct dp_vs_conn *conn)
+{
+    uint32_t ihash, ohash;
+
     if (unlikely(conn->flags & DPVS_CONN_F_HASHED))
         return EDPVS_EXIST;
 
     if (conn->flags & DPVS_CONN_F_TEMPLATE) {
+        ihash = conn_hashkey(conn->af,
+                    &tuplehash_in(conn).saddr, tuplehash_in(conn).sport,
+                    &tuplehash_in(conn).daddr, tuplehash_in(conn).dport,
+                    DPVS_CONN_TBL_MASK);
+        ohash = conn_hashkey(conn->af,
+                    &tuplehash_out(conn).saddr, tuplehash_out(conn).sport,
+                    &tuplehash_out(conn).daddr, tuplehash_out(conn).dport,
+                    DPVS_CONN_TBL_MASK);
+
         /* lock is complusory for template */
         rte_spinlock_lock(&dp_vs_ct_lock);
-        list_add(&tuplehash_in(conn).list, &dp_vs_ct_tab[ihash]);
-        list_add(&tuplehash_out(conn).list, &dp_vs_ct_tab[ohash]);
+        list_add(&tuplehash_in(conn).list, &dp_vs_ct_tbl[ihash]);
+        list_add(&tuplehash_out(conn).list, &dp_vs_ct_tbl[ohash]);
         rte_spinlock_unlock(&dp_vs_ct_lock);
     } else {
-        list_add(&tuplehash_in(conn).list, &this_conn_tab[ihash]);
-        list_add(&tuplehash_out(conn).list, &this_conn_tab[ohash]);
+        ihash = conn_hashkey(conn->af,
+                    &tuplehash_in(conn).saddr, tuplehash_in(conn).sport,
+                    &tuplehash_in(conn).daddr, tuplehash_in(conn).dport,
+                    DPVS_CONN_TBL_MASK);
+        ohash = conn_hashkey(conn->af,
+                    &tuplehash_out(conn).saddr, tuplehash_out(conn).sport,
+                    &tuplehash_out(conn).daddr, tuplehash_out(conn).dport,
+                    DPVS_CONN_TBL_MASK);
+
+        list_add(&tuplehash_in(conn).list, &this_conn_tbl[ihash]);
+        list_add(&tuplehash_out(conn).list, &this_conn_tbl[ohash]);
     }
 
     conn->flags |= DPVS_CONN_F_HASHED;
@@ -135,24 +197,17 @@ static inline int __conn_hash(struct dp_vs_conn *conn,
 
 static inline int conn_hash(struct dp_vs_conn *conn)
 {
-    uint32_t ihash, ohash;
     int err;
-
-    ihash = conn_hashkey(tuplehash_in(conn).af,
-                &tuplehash_in(conn).saddr, tuplehash_in(conn).sport,
-                &tuplehash_in(conn).daddr, tuplehash_in(conn).dport);
-
-    ohash = conn_hashkey(tuplehash_out(conn).af,
-                &tuplehash_out(conn).saddr, tuplehash_out(conn).sport,
-                &tuplehash_out(conn).daddr, tuplehash_out(conn).dport);
 
 #ifdef CONFIG_DPVS_IPVS_CONN_LOCK
     rte_spinlock_lock(&this_conn_lock);
 #endif
-    err = __conn_hash(conn, ihash, ohash);
+    err = __conn_hash(conn);
 #ifdef CONFIG_DPVS_IPVS_CONN_LOCK
     rte_spinlock_unlock(&this_conn_lock);
 #endif
+
+    dp_vs_redirect_hash(conn);
 
     return err;
 }
@@ -168,6 +223,8 @@ static inline int conn_unhash(struct dp_vs_conn *conn)
         if (rte_atomic32_read(&conn->refcnt) != 2) {
             err = EDPVS_BUSY;
         } else {
+            dp_vs_redirect_unhash(conn);
+
             if (conn->flags & DPVS_CONN_F_TEMPLATE) {
                 rte_spinlock_lock(&dp_vs_ct_lock);
                 list_del(&tuplehash_in(conn).list);
@@ -179,6 +236,7 @@ static inline int conn_unhash(struct dp_vs_conn *conn)
             }
             conn->flags &= ~DPVS_CONN_F_HASHED;
             rte_atomic32_dec(&conn->refcnt);
+
             err = EDPVS_OK;
         }
     } else {
@@ -285,7 +343,7 @@ static inline void conn_dump(const char *msg, struct dp_vs_conn *conn)
     laddr = inet_ntop(conn->af, &conn->laddr, lbuf, sizeof(lbuf)) ? lbuf : "::";
     daddr = inet_ntop(conn->af, &conn->daddr, dbuf, sizeof(dbuf)) ? dbuf : "::";
 
-    RTE_LOG(DEBUG, IPVS, "%s [%d] %s %s:%u %s:%u %s:%u %s:%u refs %d\n",
+    RTE_LOG(DEBUG, IPVS, "%s [%d] %s %s/%u %s/%u %s/%u %s/%u refs %d\n",
             msg ? msg : "", rte_lcore_id(), inet_proto_name(conn->proto),
             caddr, ntohs(conn->cport), vaddr, ntohs(conn->vport),
             laddr, ntohs(conn->lport), daddr, ntohs(conn->dport),
@@ -301,14 +359,14 @@ static inline void conn_tuplehash_dump(const char *msg,
     saddr = inet_ntop(t->af, &t->saddr, sbuf, sizeof(sbuf)) ? sbuf : "::";
     daddr = inet_ntop(t->af, &t->daddr, dbuf, sizeof(dbuf)) ? dbuf : "::";
 
-    RTE_LOG(DEBUG, IPVS, "%s%s %s %s:%u->%s:%u\n",
+    RTE_LOG(DEBUG, IPVS, "%s%s %s %s/%u->%s/%u\n",
             msg ? msg : "",
             t->direct == DPVS_CONN_DIR_INBOUND ? "in " : "out",
             inet_proto_name(t->proto),
             saddr, ntohs(t->sport), daddr, ntohs(t->dport));
 }
 
-static inline void conn_tab_dump(void)
+static inline void conn_table_dump(void)
 {
     int i;
     struct conn_tuple_hash *tuphash;
@@ -319,13 +377,13 @@ static inline void conn_tab_dump(void)
     rte_spinlock_lock(&this_conn_lock);
 #endif
 
-    for (i = 0; i < DPVS_CONN_TAB_SIZE; i++) {
-        if (list_empty(&this_conn_tab[i]))
+    for (i = 0; i < DPVS_CONN_TBL_SIZE; i++) {
+        if (list_empty(&this_conn_tbl[i]))
             continue;
 
         RTE_LOG(DEBUG, IPVS, "    hash %d\n", i);
 
-        list_for_each_entry(tuphash, &this_conn_tab[i], list) {
+        list_for_each_entry(tuphash, &this_conn_tbl[i], list) {
             conn_tuplehash_dump("        ", tuphash);
         }
     }
@@ -348,7 +406,7 @@ static inline void conn_stats_dump(const char *msg, struct dp_vs_conn *conn)
         laddr = inet_ntop(conn->af, &conn->laddr, lbuf, sizeof(lbuf)) ? lbuf : "::";
         daddr = inet_ntop(conn->af, &conn->daddr, dbuf, sizeof(dbuf)) ? dbuf : "::";
 
-        RTE_LOG(DEBUG, IPVS, "[%s->%s]%s [%d] %s %s:%u %s:%u %s:%u %s:%u"
+        RTE_LOG(DEBUG, IPVS, "[%s->%s]%s [%d] %s %s/%u %s/%u %s/%u %s/%u"
                 " inpkts=%ld, inbytes=%ld, outpkts=%ld, outbytes=%ld\n",
                 cycles_to_stime(conn->ctime), sys_localtime_str(),
                 msg ? msg : "", rte_lcore_id(), inet_proto_name(conn->proto),
@@ -500,15 +558,15 @@ static int conn_expire(void *priv)
 
         rte_atomic32_dec(&conn->refcnt);
 
-        rte_mempool_put(conn->connpool, conn);
-        this_conn_count--;
-
 #ifdef CONFIG_DPVS_IPVS_STATS_DEBUG
         conn_stats_dump("del conn", conn);
 #endif
 #ifdef CONFIG_DPVS_IPVS_DEBUG
         conn_dump("del conn: ", conn);
 #endif
+
+        dp_vs_conn_free(conn);
+
         return DTIMER_STOP;
     }
 
@@ -534,8 +592,8 @@ static void conn_flush(void)
 #ifdef CONFIG_DPVS_IPVS_CONN_LOCK
     rte_spinlock_lock(&this_conn_lock);
 #endif
-    for (i = 0; i < DPVS_CONN_TAB_SIZE; i++) {
-        list_for_each_entry_safe(tuphash, next, &this_conn_tab[i], list) {
+    for (i = 0; i < DPVS_CONN_TBL_SIZE; i++) {
+        list_for_each_entry_safe(tuphash, next, &this_conn_tbl[i], list) {
             conn = tuplehash_to_conn(tuphash);
 
             if (conn->flags & DPVS_CONN_F_TEMPLATE)
@@ -590,8 +648,8 @@ static void conn_flush(void)
                 dp_vs_laddr_unbind(conn);
                 rte_atomic32_dec(&conn->refcnt);
 
-                rte_mempool_put(conn->connpool, conn);
-                this_conn_count--;
+                dp_vs_conn_free(conn);
+
 #ifdef CONFIG_DPVS_IPVS_STATS_DEBUG
                 conn_stats_dump("conn flush", conn);
 #endif
@@ -609,6 +667,7 @@ struct dp_vs_conn *dp_vs_conn_new(struct rte_mbuf *mbuf,
                                   struct dp_vs_dest *dest, uint32_t flags)
 {
     struct dp_vs_conn *new;
+    struct dp_vs_redirect *new_r = NULL;
     struct conn_tuple_hash *t;
     uint16_t rport;
     __be16 _ports[2], *ports;
@@ -616,12 +675,16 @@ struct dp_vs_conn *dp_vs_conn_new(struct rte_mbuf *mbuf,
 
     assert(mbuf && param && dest);
 
-    if (unlikely(rte_mempool_get(this_conn_cache, (void **)&new) != 0)) {
-        RTE_LOG(WARNING, IPVS, "%s: no memory\n", __func__);
-        return NULL;
+    /* no need to create redirect for the global template connection */
+    if ((flags & DPVS_CONN_F_TEMPLATE) == 0) {
+        new_r = dp_vs_redirect_alloc(dest->fwdmode);
     }
-    memset(new, 0, sizeof(struct dp_vs_conn));
-    new->connpool = this_conn_cache;
+
+    new = dp_vs_conn_alloc();
+    if (unlikely(!new))
+        goto errout_redirect;
+
+    new->redirect = new_r;
 
     /* set proper RS port */
     if ((flags & DPVS_CONN_F_TEMPLATE) || param->ct_dport != 0)
@@ -656,7 +719,7 @@ struct dp_vs_conn *dp_vs_conn_new(struct rte_mbuf *mbuf,
     /* init outbound conn tuple hash */
     t = &tuplehash_out(new);
     t->direct   = DPVS_CONN_DIR_OUTBOUND;
-    t->af       = dest->af;
+    t->af       = param->af;
     t->proto    = param->proto;
     if (dest->fwdmode == DPVS_FWD_MODE_SNAT)
         t->saddr = iph->saddr;
@@ -676,11 +739,10 @@ struct dp_vs_conn *dp_vs_conn_new(struct rte_mbuf *mbuf,
     new->vport  = param->vport;
     new->laddr  = *param->caddr;    /* non-FNAT */
     new->lport  = param->cport;     /* non-FNAT */
-    if (dest->fwdmode == DPVS_FWD_MODE_SNAT) {
+    if (dest->fwdmode == DPVS_FWD_MODE_SNAT)
         new->daddr  = iph->saddr;
-    } else {
+    else
         new->daddr  = dest->addr;
-    }
     new->dport  = rport;
 
     /* neighbour confirm cache */
@@ -725,6 +787,9 @@ struct dp_vs_conn *dp_vs_conn_new(struct rte_mbuf *mbuf,
         if ((err = dp_vs_laddr_bind(new, dest->svc)) != EDPVS_OK)
             goto unbind_dest;
     }
+
+    /* init redirect if it exists */
+    dp_vs_redirect_init(new);
 
     /* add to hash table (dual dir for each bucket) */
     if ((err = conn_hash(new)) != EDPVS_OK)
@@ -771,8 +836,6 @@ struct dp_vs_conn *dp_vs_conn_new(struct rte_mbuf *mbuf,
         new->timeout.tv_sec = pp->timeout_table[new->state = DPVS_TCP_S_SYN_SENT];
     }
 
-    this_conn_count++;
-
     /* schedule conn timer */
     dpvs_time_rand_delay(&new->timeout, 1000000);
     if (new->flags & DPVS_CONN_F_TEMPLATE)
@@ -790,7 +853,9 @@ unbind_laddr:
 unbind_dest:
     conn_unbind_dest(new);
 errout:
-    rte_mempool_put(this_conn_cache, new);
+    dp_vs_conn_free(new);
+errout_redirect:
+    dp_vs_redirect_free(new);
     return NULL;
 }
 
@@ -813,16 +878,19 @@ struct dp_vs_conn *dp_vs_conn_get(int af, uint16_t proto,
     char sbuf[64], dbuf[64];
 #endif
 
-    if (unlikely(reverse))
-        hash = conn_hashkey(af, daddr, dport, saddr, sport);
-    else
-        hash = conn_hashkey(af, saddr, sport, daddr, dport);
+    if (unlikely(reverse)) {
+        hash = conn_hashkey(af, daddr, dport, saddr, sport,
+                            DPVS_CONN_TBL_MASK);
+    } else {
+        hash = conn_hashkey(af, saddr, sport, daddr, dport,
+                            DPVS_CONN_TBL_MASK);
+    }
 
 #ifdef CONFIG_DPVS_IPVS_CONN_LOCK
     rte_spinlock_lock(&this_conn_lock);
 #endif
     if (unlikely(reverse)) { /* swap source/dest for lookup */
-        list_for_each_entry(tuphash, &this_conn_tab[hash], list) {
+        list_for_each_entry(tuphash, &this_conn_tbl[hash], list) {
             if (tuphash->sport == dport
                     && tuphash->dport == sport
                     && inet_addr_equal(af, &tuphash->saddr, daddr)
@@ -838,7 +906,7 @@ struct dp_vs_conn *dp_vs_conn_get(int af, uint16_t proto,
             }
         }
     } else {
-        list_for_each_entry(tuphash, &this_conn_tab[hash], list) {
+        list_for_each_entry(tuphash, &this_conn_tbl[hash], list) {
             if (tuphash->sport == sport
                     && tuphash->dport == dport
                     && inet_addr_equal(af, &tuphash->saddr, saddr)
@@ -859,7 +927,7 @@ struct dp_vs_conn *dp_vs_conn_get(int af, uint16_t proto,
 #endif
 
 #ifdef CONFIG_DPVS_IPVS_DEBUG
-    RTE_LOG(DEBUG, IPVS, "conn lookup: [%d] %s %s:%d -> %s:%d %s %s\n",
+    RTE_LOG(DEBUG, IPVS, "conn lookup: [%d] %s %s/%d -> %s/%d %s %s\n",
             rte_lcore_id(), inet_proto_name(proto),
             inet_ntop(af, saddr, sbuf, sizeof(sbuf)) ? sbuf : "::", ntohs(sport),
             inet_ntop(af, daddr, dbuf, sizeof(dbuf)) ? dbuf : "::", ntohs(dport),
@@ -882,10 +950,10 @@ struct dp_vs_conn *dp_vs_ct_in_get(int af, uint16_t proto,
     char sbuf[64], dbuf[64];
 #endif
 
-    hash = conn_hashkey(af, saddr, sport, daddr, dport);
+    hash = conn_hashkey(af, saddr, sport, daddr, dport, DPVS_CONN_TBL_MASK);
 
     rte_spinlock_lock(&dp_vs_ct_lock);
-    list_for_each_entry(tuphash, &dp_vs_ct_tab[hash], list) {
+    list_for_each_entry(tuphash, &dp_vs_ct_tbl[hash], list) {
         conn = tuplehash_to_conn(tuphash);
         if (tuphash->sport == sport && tuphash->dport == dport
                 && inet_addr_equal(af, &tuphash->saddr, saddr)
@@ -902,7 +970,7 @@ struct dp_vs_conn *dp_vs_ct_in_get(int af, uint16_t proto,
     rte_spinlock_unlock(&dp_vs_ct_lock);
 
 #ifdef CONFIG_DPVS_IPVS_DEBUG
-    RTE_LOG(DEBUG, IPVS, "conn-template lookup: [%d] %s %s:%d -> %s:%d %s\n",
+    RTE_LOG(DEBUG, IPVS, "conn-template lookup: [%d] %s %s/%d -> %s/%d %s\n",
             rte_lcore_id(), inet_proto_name(proto),
             inet_ntop(af, saddr, sbuf, sizeof(sbuf)) ? sbuf : "::", ntohs(sport),
             inet_ntop(af, daddr, dbuf, sizeof(dbuf)) ? dbuf : "::", ntohs(dport),
@@ -927,7 +995,7 @@ int dp_vs_check_template(struct dp_vs_conn *ct)
              rte_atomic16_read(&dest->weight) == 0)) {
 #ifdef CONFIG_DPVS_IPVS_DEBUG
         RTE_LOG(DEBUG, IPVS, "%s: check_template: dest not available for "
-                "protocol %s s:%s:%u v:%s:%u -> l:%s:%u d:%s:%u\n",
+                "protocol %s s:%s/%u v:%s/%u -> l:%s/%u d:%s/%u\n",
                 __func__, inet_proto_name(ct->proto),
                 inet_ntop(ct->af, &ct->caddr, sbuf, sizeof(sbuf)) ? sbuf : "::",
                 ntohs(ct->cport),
@@ -978,14 +1046,17 @@ static int conn_init_lcore(void *arg)
     if (!rte_lcore_is_enabled(rte_lcore_id()))
         return EDPVS_DISABLED;
 
-    this_conn_tab = rte_malloc_socket(NULL,
-                        sizeof(struct list_head) * DPVS_CONN_TAB_SIZE,
+    if (netif_lcore_is_idle(rte_lcore_id()))
+        return EDPVS_IDLE;
+
+    this_conn_tbl = rte_malloc_socket(NULL,
+                        sizeof(struct list_head) * DPVS_CONN_TBL_SIZE,
                         RTE_CACHE_LINE_SIZE, rte_socket_id());
-    if (!this_conn_tab)
+    if (!this_conn_tbl)
         return EDPVS_NOMEM;
 
-    for (i = 0; i < DPVS_CONN_TAB_SIZE; i++)
-        INIT_LIST_HEAD(&this_conn_tab[i]);
+    for (i = 0; i < DPVS_CONN_TBL_SIZE; i++)
+        INIT_LIST_HEAD(&this_conn_tbl[i]);
 
 #ifdef CONFIG_DPVS_IPVS_CONN_LOCK
     rte_spinlock_init(&this_conn_lock);
@@ -1002,14 +1073,13 @@ static int conn_term_lcore(void *arg)
 
     conn_flush();
 
-    if (this_conn_tab) {
-        rte_free(this_conn_tab);
-        this_conn_tab = NULL;
+    if (this_conn_tbl) {
+        rte_free(this_conn_tbl);
+        this_conn_tbl = NULL;
     }
 
     return EDPVS_OK;
 }
-
 
 /*
  * ctrl plane support for commands:
@@ -1183,7 +1253,7 @@ static int __lcore_conn_table_dump(const struct list_head *cplist)
     struct dp_vs_conn *conn;
     struct ip_vs_conn_array_list *cparr = NULL;
 
-    for (i = 0; i < DPVS_CONN_TAB_SIZE; i++) {
+    for (i = 0; i < DPVS_CONN_TBL_SIZE; i++) {
         list_for_each_entry(tuphash, &cplist[i], list) {
             if (tuphash->direct != DPVS_CONN_DIR_INBOUND)
                 continue;
@@ -1263,7 +1333,7 @@ again:
     if ((conn_req->flag & GET_IPVS_CONN_FLAG_TEMPLATE)
             && (cid == rte_get_master_lcore())) { /* persist conns */
         rte_spinlock_lock(&dp_vs_ct_lock);
-        res = __lcore_conn_table_dump(dp_vs_ct_tab);
+        res = __lcore_conn_table_dump(dp_vs_ct_tbl);
         rte_spinlock_unlock(&dp_vs_ct_lock);
         if (res != EDPVS_OK) {
             conn_arr->nconns = got;
@@ -1435,7 +1505,7 @@ static int conn_get_msgcb_slave(struct dpvs_msg *msg)
 
 static int conn_get_all_msgcb_slave(struct dpvs_msg *msg)
 {
-    return  __lcore_conn_table_dump(this_conn_tab);
+    return  __lcore_conn_table_dump(this_conn_tbl);
 }
 
 static int register_conn_get_msg(void)
@@ -1548,10 +1618,11 @@ int dp_vs_conn_init(void)
     char poolname[32];
 
     /* init connection template table */
-    dp_vs_ct_tab = rte_malloc_socket(NULL, sizeof(struct list_head) * DPVS_CONN_TAB_SIZE,
+    dp_vs_ct_tbl = rte_malloc_socket(NULL, sizeof(struct list_head) * DPVS_CONN_TBL_SIZE,
             RTE_CACHE_LINE_SIZE, rte_socket_id());
-    for (i = 0; i < DPVS_CONN_TAB_SIZE; i++)
-        INIT_LIST_HEAD(&dp_vs_ct_tab[i]);
+
+    for (i = 0; i < DPVS_CONN_TBL_SIZE; i++)
+        INIT_LIST_HEAD(&dp_vs_ct_tbl[i]);
     rte_spinlock_init(&dp_vs_ct_lock);
 
     /*
@@ -1609,21 +1680,33 @@ int dp_vs_conn_term(void)
     return EDPVS_OK;
 }
 
+int dp_vs_conn_pool_size(void)
+{
+    return conn_pool_size;
+}
+
+int dp_vs_conn_pool_cache_size(void)
+{
+    return conn_pool_cache;
+}
+
 static void conn_pool_size_handler(vector_t tokens)
 {
     char *str = set_value(tokens);
-    int pktpool_size;
+    int pool_size;
 
     assert(str);
-    pktpool_size = atoi(str);
-    if (pktpool_size < DPVS_CONN_POOL_SIZE_MIN) {
+
+    pool_size = atoi(str);
+
+    if (pool_size < DPVS_CONN_POOL_SIZE_MIN) {
         RTE_LOG(WARNING, IPVS, "invalid conn_pool_size %s, using default %d\n",
                 str, DPVS_CONN_POOL_SIZE_DEF);
         conn_pool_size = DPVS_CONN_POOL_SIZE_DEF;
     } else {
-        is_power2(pktpool_size, 0, &pktpool_size);
-        RTE_LOG(INFO, IPVS, "conn_pool_size = %d (round to 2^n)\n", pktpool_size);
-        conn_pool_size = pktpool_size;
+        is_power2(pool_size, 0, &pool_size);
+        RTE_LOG(INFO, IPVS, "conn_pool_size = %d (round to 2^n)\n", pool_size);
+        conn_pool_size = pool_size;
     }
 
     FREE_PTR(str);
@@ -1632,13 +1715,14 @@ static void conn_pool_size_handler(vector_t tokens)
 static void conn_pool_cache_handler(vector_t tokens)
 {
     char *str = set_value(tokens);
-    int pktpool_cache;
+    int pool_cache;
 
     assert(str);
-    if ((pktpool_cache = atoi(str)) > 0) {
-        is_power2(pktpool_cache, 0, &pktpool_cache);
-        RTE_LOG(INFO, IPVS, "conn_pool_cache = %d (round to 2^n)\n", pktpool_cache);
-        conn_pool_cache = pktpool_cache;
+
+    if ((pool_cache = atoi(str)) > 0) {
+        is_power2(pool_cache, 0, &pool_cache);
+        RTE_LOG(INFO, IPVS, "conn_pool_cache = %d (round to 2^n)\n", pool_cache);
+        conn_pool_cache = pool_cache;
     } else {
         RTE_LOG(WARNING, IPVS, "invalid conn_pool_cache %s, using default %d\n",
                 str, DPVS_CONN_CACHE_SIZE_DEF);
@@ -1654,7 +1738,9 @@ static void conn_init_timeout_handler(vector_t tokens)
     int init_timeout;
 
     assert(str);
+
     init_timeout = atoi(str);
+
     if (init_timeout > IPVS_TIMEOUT_MIN && init_timeout < IPVS_TIMEOUT_MAX) {
         RTE_LOG(INFO, IPVS, "conn_init_timeout = %d\n", init_timeout);
         conn_init_timeout = init_timeout;

--- a/src/ipvs/ip_vs_core.c
+++ b/src/ipvs/ip_vs_core.c
@@ -36,6 +36,7 @@
 #include "ipvs/blklst.h"
 #include "ipvs/proto_udp.h"
 #include "route6.h"
+#include "ipvs/redirect.h"
 
 static inline int dp_vs_fill_iphdr(int af, struct rte_mbuf *mbuf,
                                    struct dp_vs_iphdr *iph)
@@ -96,7 +97,7 @@ static struct dp_vs_conn *dp_vs_sched_persist(struct dp_vs_service *svc,
         return NULL;
 
 #ifdef CONFIG_DPVS_IPVS_DEBUG
-    RTE_LOG(DEBUG, IPVS, "%s: persist-schedule: src %s:%u dest %s:%u snet %s\n",
+    RTE_LOG(DEBUG, IPVS, "%s: persist-schedule: src %s/%u dest %s/%u snet %s\n",
             __func__,
             inet_ntop(svc->af, &iph->saddr, sbuf, sizeof(sbuf)),
             ntohs(ports[0]),
@@ -269,7 +270,7 @@ static struct dp_vs_conn *dp_vs_snat_schedule(struct dp_vs_dest *dest,
 }
 
 /* select an RS by service's scheduler and create a connection */
-struct dp_vs_conn *dp_vs_schedule(struct dp_vs_service *svc, 
+struct dp_vs_conn *dp_vs_schedule(struct dp_vs_service *svc,
                                   const struct dp_vs_iphdr *iph,
                                   struct rte_mbuf *mbuf,
                                   bool is_synproxy_on)
@@ -284,7 +285,7 @@ struct dp_vs_conn *dp_vs_schedule(struct dp_vs_service *svc,
     ports = mbuf_header_pointer(mbuf, iph->len, sizeof(_ports), _ports);
     if (!ports)
         return NULL;
-        
+
     /* persistent service */
     if (svc->flags & DP_VS_SVC_F_PERSISTENT)
         return dp_vs_sched_persist(svc, iph,  mbuf, is_synproxy_on);
@@ -297,7 +298,7 @@ struct dp_vs_conn *dp_vs_schedule(struct dp_vs_service *svc,
 #endif
         return NULL;
     }
-        
+
     if (dest->fwdmode == DPVS_FWD_MODE_SNAT)
         return dp_vs_snat_schedule(dest, iph, ports, mbuf);
 
@@ -344,8 +345,8 @@ struct dp_vs_conn *dp_vs_schedule(struct dp_vs_service *svc,
 }
 
 /* return verdict INET_XXX */
-static int xmit_outbound(struct rte_mbuf *mbuf, 
-                         struct dp_vs_proto *prot, 
+static int xmit_outbound(struct rte_mbuf *mbuf,
+                         struct dp_vs_proto *prot,
                          struct dp_vs_conn *conn)
 {
     int err;
@@ -383,7 +384,7 @@ static int xmit_inbound(struct rte_mbuf *mbuf,
         dp_vs_conn_put(conn);
         return INET_DROP;
     }
-      
+
     /* is dest avaible to forward the packet ? */
     if (!conn->dest) {
         /* silently drop packet without reset connection timer.
@@ -418,7 +419,7 @@ static int __xmit_outbound_icmp4(struct rte_mbuf *mbuf,
     struct ipv4_hdr *iph = ip4_hdr(mbuf);
 
     /* no translation needed for DR/TUN. */
-    if (conn->dest->fwdmode != DPVS_FWD_MODE_FNAT && 
+    if (conn->dest->fwdmode != DPVS_FWD_MODE_FNAT &&
         conn->dest->fwdmode != DPVS_FWD_MODE_NAT  &&
         conn->dest->fwdmode != DPVS_FWD_MODE_SNAT) {
         if (!conn->packet_out_xmit) {
@@ -440,10 +441,10 @@ static int __xmit_outbound_icmp4(struct rte_mbuf *mbuf,
         return EDPVS_NOROUTE;
     }
 
-    if ((mbuf->pkt_len > rt->mtu) 
+    if ((mbuf->pkt_len > rt->mtu)
             && (ip4_hdr(mbuf)->fragment_offset & IPV4_HDR_DF_FLAG)) {
         route4_put(rt);
-        icmp_send(mbuf, ICMP_DEST_UNREACH, ICMP_UNREACH_NEEDFRAG, 
+        icmp_send(mbuf, ICMP_DEST_UNREACH, ICMP_UNREACH_NEEDFRAG,
                   htonl(rt->mtu));
         rte_pktmbuf_free(mbuf);
         return EDPVS_FRAG;
@@ -531,7 +532,7 @@ static int __xmit_inbound_icmp4(struct rte_mbuf *mbuf,
     struct ipv4_hdr *iph = ip4_hdr(mbuf);
 
     /* no translation needed for DR/TUN. */
-    if (conn->dest->fwdmode != DPVS_FWD_MODE_NAT  && 
+    if (conn->dest->fwdmode != DPVS_FWD_MODE_NAT  &&
 	conn->dest->fwdmode != DPVS_FWD_MODE_FNAT &&
 	conn->dest->fwdmode != DPVS_FWD_MODE_SNAT) {
         if (!conn->packet_xmit) {
@@ -553,10 +554,10 @@ static int __xmit_inbound_icmp4(struct rte_mbuf *mbuf,
         return EDPVS_NOROUTE;
     }
 
-    if ((mbuf->pkt_len > rt->mtu) 
+    if ((mbuf->pkt_len > rt->mtu)
             && (ip4_hdr(mbuf)->fragment_offset & IPV4_HDR_DF_FLAG)) {
         route4_put(rt);
-        icmp_send(mbuf, ICMP_DEST_UNREACH, ICMP_UNREACH_NEEDFRAG, 
+        icmp_send(mbuf, ICMP_DEST_UNREACH, ICMP_UNREACH_NEEDFRAG,
                   htonl(rt->mtu));
         rte_pktmbuf_free(mbuf);
         return EDPVS_FRAG;
@@ -646,9 +647,11 @@ static int __dp_vs_in_icmp4(struct rte_mbuf *mbuf, int *related)
     struct dp_vs_proto *prot;
     struct dp_vs_conn *conn;
     int off, dir, err;
+    lcoreid_t cid, peer_cid;
     bool drop = false;
 
     *related = 0; /* not related until found matching conn */
+    cid = peer_cid = rte_lcore_id();
 
     if (unlikely(ip4_is_frag(iph))) {
         if (ip4_defrag(mbuf, IP_DEFRAG_VS_FWD) != EDPVS_OK)
@@ -689,9 +692,9 @@ static int __dp_vs_in_icmp4(struct rte_mbuf *mbuf, int *related)
         return INET_DROP;
     }
 
-    /* 
+    /*
      * lookup conn with inner IP pkt.
-     * it need to move mbuf.data_off to inner IP pkt, 
+     * it need to move mbuf.data_off to inner IP pkt,
      * and restore it later. although it looks strange.
      */
     rte_pktmbuf_adj(mbuf, off);
@@ -699,7 +702,19 @@ static int __dp_vs_in_icmp4(struct rte_mbuf *mbuf, int *related)
         return INET_DROP;
     dp_vs_fill_iphdr(AF_INET, mbuf, &dciph);
 
-    conn = prot->conn_lookup(prot, &dciph, mbuf, &dir, true, &drop);
+    conn = prot->conn_lookup(prot, &dciph, mbuf, &dir, true, &drop, &peer_cid);
+
+    /*
+     * The connection is not locally found, however the redirect is found so
+     * forward the packet to the remote redirect owner core.
+     */
+    if (cid != peer_cid) {
+        /* recover mbuf.data_off to outer Ether header */
+        rte_pktmbuf_prepend(mbuf, (uint16_t)sizeof(struct ether_hdr) + off);
+
+        return dp_vs_redirect_pkt(mbuf, peer_cid);
+    }
+
     if (!conn)
         return INET_ACCEPT;
 
@@ -728,7 +743,7 @@ static int __dp_vs_in_icmp4(struct rte_mbuf *mbuf, int *related)
         dp_vs_conn_put(conn);
         return INET_DROP;
     }
-    /* note 
+    /* note
      * 1. the direction of inner IP pkt is reversed with ICMP pkt.
      * 2. but we use (@reverse == true) for prot->conn_lookup()
      * as a result, @dir is same with icmp packet. */
@@ -737,7 +752,7 @@ static int __dp_vs_in_icmp4(struct rte_mbuf *mbuf, int *related)
     else
         err = xmit_outbound_icmp(mbuf, prot, conn);
     if (err != EDPVS_OK)
-        RTE_LOG(WARNING, IPVS, "%s: xmit icmp error: %s\n", 
+        RTE_LOG(WARNING, IPVS, "%s: xmit icmp error: %s\n",
                 __func__, dpvs_strerror(err));
 
     dp_vs_conn_put_no_reset(conn);
@@ -754,6 +769,7 @@ static int __dp_vs_in_icmp6(struct rte_mbuf *mbuf, int *related)
     struct dp_vs_proto *prot;
     struct dp_vs_conn *conn;
     int off, ic6h_off, dir, err;
+    lcoreid_t cid, peer_cid;
     bool drop = false;
     uint8_t nexthdr = ip6h->ip6_nxt;
 #ifdef CONFIG_DPVS_IPVS_DEBUG
@@ -761,6 +777,7 @@ static int __dp_vs_in_icmp6(struct rte_mbuf *mbuf, int *related)
 #endif
 
     *related = 0; /* not related until found matching conn */
+    cid = peer_cid = rte_lcore_id();
 
     // don't suppurt frag now
     if (unlikely(ip6_is_frag(ip6h))) {
@@ -784,8 +801,8 @@ static int __dp_vs_in_icmp6(struct rte_mbuf *mbuf, int *related)
 #ifdef CONFIG_DPVS_IPVS_DEBUG
     inet_ntop(AF_INET6, &ip6h->ip6_src, src_addr_buff, sizeof(src_addr_buff));
     inet_ntop(AF_INET6, &ip6h->ip6_dst, dst_addr_buff, sizeof(dst_addr_buff));
-    RTE_LOG(DEBUG, IPVS, "ICMP6 (%d,%d) %s->%s\n",
-            ic6h->icmp6_type, ntohs(icmp6h_id(ic6h)), src_addr_buff, dst_addr_buff);
+    RTE_LOG(DEBUG, IPVS, "%s: ICMP6 (%d, %d) %s->%s\n",
+            __func__, ic6h->icmp6_type, ntohs(icmp6h_id(ic6h)), src_addr_buff, dst_addr_buff);
 #endif
 
     /* support these related error types only,
@@ -821,7 +838,19 @@ static int __dp_vs_in_icmp6(struct rte_mbuf *mbuf, int *related)
     if (!prot)
         return INET_ACCEPT;
 
-    conn = prot->conn_lookup(prot, &dcip6h, mbuf, &dir, true, &drop);
+    conn = prot->conn_lookup(prot, &dcip6h, mbuf, &dir, true, &drop, &peer_cid);
+
+    /*
+     * The connection is not locally found, however the redirect is found so
+     * forward the packet to the remote redirect owner core.
+     */
+    if (cid != peer_cid) {
+        /* recover mbuf.data_off to outer Ether header */
+        rte_pktmbuf_prepend(mbuf, (uint16_t)sizeof(struct ether_hdr) + off);
+
+        return dp_vs_redirect_pkt(mbuf, peer_cid);
+    }
+
     if (!conn)
         return INET_ACCEPT;
 
@@ -862,7 +891,7 @@ static int __dp_vs_in_icmp6(struct rte_mbuf *mbuf, int *related)
     else
         err = xmit_outbound_icmp(mbuf, prot, conn);
     if (err != EDPVS_OK)
-        RTE_LOG(WARNING, IPVS, "%s: xmit icmp error: %s\n", 
+        RTE_LOG(WARNING, IPVS, "%s: xmit icmp error: %s\n",
                 __func__, dpvs_strerror(err));
 
     dp_vs_conn_put_no_reset(conn);
@@ -893,8 +922,11 @@ static int __dp_vs_in(void *priv, struct rte_mbuf *mbuf,
     struct dp_vs_conn *conn;
     int dir, verdict, err, related;
     bool drop = false;
+    lcoreid_t cid, peer_cid;
     eth_type_t etype = mbuf->packet_type; /* FIXME: use other field ? */
     assert(mbuf && state);
+
+    cid = peer_cid = rte_lcore_id();
 
     if (unlikely(etype != ETH_PKT_HOST))
         return INET_ACCEPT;
@@ -908,7 +940,7 @@ static int __dp_vs_in(void *priv, struct rte_mbuf *mbuf,
         verdict = dp_vs_in_icmp(af, mbuf, &related);
         if (related || verdict != INET_ACCEPT)
             return verdict;
-        /* let unrelated and valid ICMP goes down, 
+        /* let unrelated and valid ICMP goes down,
          * may implement ICMP fwd in the futher. */
     }
 
@@ -934,11 +966,22 @@ static int __dp_vs_in(void *priv, struct rte_mbuf *mbuf,
     }
 
     /* packet belongs to existing connection ? */
-    conn = prot->conn_lookup(prot, &iph, mbuf, &dir, false, &drop);
+    conn = prot->conn_lookup(prot, &iph, mbuf, &dir, false, &drop, &peer_cid);
 
     if (unlikely(drop)) {
         RTE_LOG(DEBUG, IPVS, "%s: deny ip try to visit.\n", __func__);
         return INET_DROP;
+    }
+
+    /*
+     * The connection is not locally found, however the redirect is found so
+     * forward the packet to the remote redirect owner core.
+     */
+    if (cid != peer_cid) {
+        /* recover mbuf.data_off to outer Ether header */
+        rte_pktmbuf_prepend(mbuf, (uint16_t)sizeof(struct ether_hdr));
+
+        return dp_vs_redirect_pkt(mbuf, peer_cid);
     }
 
     if (unlikely(!conn)) {
@@ -1111,6 +1154,12 @@ int dp_vs_init(void)
         goto err_conn;
     }
 
+    err = dp_vs_redirects_init();
+    if (err != EDPVS_OK) {
+        RTE_LOG(ERR, IPVS, "fail to init redirect: %s\n", dpvs_strerror(err));
+        goto err_redirect;
+    }
+
     err = dp_vs_synproxy_init();
     if (err != EDPVS_OK) {
         RTE_LOG(ERR, IPVS, "fail to init synproxy: %s\n", dpvs_strerror(err));
@@ -1128,16 +1177,19 @@ int dp_vs_init(void)
         RTE_LOG(ERR, IPVS, "fail to init serv: %s\n", dpvs_strerror(err));
         goto err_serv;
     }
+
     err = dp_vs_blklst_init();
     if (err != EDPVS_OK) {
         RTE_LOG(ERR, IPVS, "fail to init blklst: %s\n", dpvs_strerror(err));
         goto err_blklst;
     }
+
     err = dp_vs_stats_init();
     if (err != EDPVS_OK) {
         RTE_LOG(ERR, IPVS, "fail to init stats: %s\n", dpvs_strerror(err));
         goto err_stats;
     }
+
     err = inet_register_hooks(dp_vs_ops, NELEMS(dp_vs_ops));
     if (err != EDPVS_OK) {
         RTE_LOG(ERR, IPVS, "fail to register hooks: %s\n", dpvs_strerror(err));
@@ -1158,6 +1210,8 @@ err_serv:
 err_sched:
     dp_vs_synproxy_term();
 err_synproxy:
+    dp_vs_redirects_term();
+err_redirect:
     dp_vs_conn_term();
 err_conn:
     dp_vs_laddr_term();
@@ -1181,7 +1235,7 @@ int dp_vs_term(void)
 
     err = dp_vs_blklst_term();
     if (err != EDPVS_OK)
-        RTE_LOG(ERR, IPVS, "fail to terminate blklst: %s\n", dpvs_strerror(err)); 
+        RTE_LOG(ERR, IPVS, "fail to terminate blklst: %s\n", dpvs_strerror(err));
 
     err = dp_vs_service_term();
     if (err != EDPVS_OK)
@@ -1194,6 +1248,10 @@ int dp_vs_term(void)
     err = dp_vs_synproxy_term();
     if (err != EDPVS_OK)
         RTE_LOG(ERR, IPVS, "fail to terminate synproxy: %s\n", dpvs_strerror(err));
+
+    err = dp_vs_redirects_term();
+    if (err != EDPVS_OK)
+        RTE_LOG(ERR, IPVS, "fail to terminate redirect: %s\n", dpvs_strerror(err));
 
     err = dp_vs_conn_term();
     if (err != EDPVS_OK)

--- a/src/ipvs/ip_vs_redirect.c
+++ b/src/ipvs/ip_vs_redirect.c
@@ -1,0 +1,387 @@
+/*
+ * DPVS is a software load balancer (Virtual Server) based on DPDK.
+ *
+ * Copyright (C) 2017 iQIYI (www.iqiyi.com).
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+#include "ipvs/redirect.h"
+
+#define DPVS_REDIRECT_RING_SIZE  4096
+
+#define DPVS_CR_TBL_BITS   22
+#define DPVS_CR_TBL_SIZE   (1 << DPVS_CR_TBL_BITS)
+#define DPVS_CR_TBL_MASK   (DPVS_CR_TBL_SIZE)
+
+static struct list_head   *dp_vs_cr_tab;
+static rte_spinlock_t      dp_vs_cr_lock[DPVS_CR_TBL_SIZE];
+static struct rte_mempool *dp_vs_cr_cache[DPVS_MAX_SOCKET];
+#define this_cr_cache      (dp_vs_cr_cache[rte_socket_id()])
+
+static struct rte_ring    *dp_vs_redirect_ring[DPVS_MAX_LCORE][DPVS_MAX_LCORE];
+
+#ifdef CONFIG_DPVS_IPVS_DEBUG
+static inline void
+dp_vs_redirect_show(struct dp_vs_redirect *r, const char *action)
+{
+    char sbuf[64], dbuf[64];
+
+    if (r->proto != IPPROTO_ICMPV6) {
+        RTE_LOG(DEBUG, IPVS, "[%d] redirect %s: [%d] %s %s/%d -> %s/%d\n",
+                rte_lcore_id(), action, r->cid,
+                inet_proto_name(r->proto),
+                inet_ntop(r->af, &r->saddr, sbuf, sizeof(sbuf)) ? sbuf : "::",
+                ntohs(r->sport),
+                inet_ntop(r->af, &r->daddr, dbuf, sizeof(dbuf)) ? dbuf : "::",
+                ntohs(r->dport));
+    }
+}
+#endif
+
+struct dp_vs_redirect *
+dp_vs_redirect_alloc(enum dpvs_fwd_mode fwdmode)
+{
+    struct dp_vs_redirect *r;
+
+    /*
+     * Currently, IPv6 support has the below issues.
+     * a) Fdir IPv6 rules fail to be created with "perfect" mode, but can be
+     * created with "signature" mode.
+     *
+     * b) In full-nat mode, the packets from incoming direction and outgoing
+     *   direction are dispatched to the different cores so the service is
+     *   broken.
+     *
+     * The solutuion is to use decentralized packet dispatch for the symemtric
+     * service modes, full-nat/snat/nat before issue a) is fixed.
+     */
+    if (fwdmode != DPVS_FWD_MODE_FNAT
+        && fwdmode != DPVS_FWD_MODE_SNAT
+        && fwdmode != DPVS_FWD_MODE_NAT) {
+        return NULL;
+    }
+
+    if (unlikely(rte_mempool_get(this_cr_cache, (void **)&r) != 0)) {
+        RTE_LOG(WARNING, IPVS,
+                "%s: no memory for redirect\n", __func__);
+        return NULL;
+    }
+
+    memset(r, 0, sizeof(struct dp_vs_redirect));
+    r->redirect_pool = this_cr_cache;
+
+    return r;
+}
+
+void dp_vs_redirect_free(struct dp_vs_conn *conn)
+{
+    if (conn->redirect) {
+#ifdef CONFIG_DPVS_IPVS_DEBUG
+        dp_vs_redirect_show(conn->redirect, "free");
+#endif
+        rte_mempool_put(this_cr_cache, conn->redirect);
+        conn->redirect = NULL;
+    }
+}
+
+void dp_vs_redirect_hash(struct dp_vs_conn *conn)
+{
+    uint32_t hash;
+    struct dp_vs_redirect *r = conn->redirect;
+
+    if (unlikely(dp_vs_conn_is_redirect_hashed(conn))) {
+        return;
+    }
+
+    hash = dp_vs_conn_hashkey(conn->af,
+                    &tuplehash_out(conn).saddr, tuplehash_out(conn).sport,
+                    &tuplehash_out(conn).daddr, tuplehash_out(conn).dport,
+                    DPVS_CR_TBL_MASK);
+
+    rte_spinlock_lock(&dp_vs_cr_lock[hash]);
+    list_add(&r->list, &dp_vs_cr_tab[hash]);
+    rte_spinlock_unlock(&dp_vs_cr_lock[hash]);
+
+    dp_vs_conn_set_redirect_hashed(conn);
+}
+
+void dp_vs_redirect_unhash(struct dp_vs_conn *conn)
+{
+    uint32_t hash;
+    struct dp_vs_redirect *r = conn->redirect;
+
+    if (likely(dp_vs_conn_is_redirect_hashed(conn))) {
+        hash = dp_vs_conn_hashkey(r->af,
+                                  &r->saddr, r->sport,
+                                  &r->daddr, r->dport,
+                                  DPVS_CR_TBL_MASK);
+
+        rte_spinlock_lock(&dp_vs_cr_lock[hash]);
+        list_del(&r->list);
+        rte_spinlock_unlock(&dp_vs_cr_lock[hash]);
+
+        dp_vs_conn_clear_redirect_hashed(conn);
+    }
+}
+
+void dp_vs_redirect_init(struct dp_vs_conn *conn)
+{
+    enum dpvs_fwd_mode fm = conn->dest->fwdmode;
+    struct conn_tuple_hash *t = &tuplehash_out(conn);
+    struct dp_vs_redirect *r = conn->redirect;
+
+    if (!conn->redirect) {
+        return;
+    }
+
+    switch (fm) {
+    case DPVS_FWD_MODE_FNAT:
+    case DPVS_FWD_MODE_NAT:
+        t = &tuplehash_out(conn);
+        break;
+
+    case DPVS_FWD_MODE_SNAT:
+        t = &tuplehash_in(conn);
+        break;
+
+    default:
+        RTE_LOG(ERR, IPVS,
+                "%s: no redirect created for fwd mode %d\n",
+                __func__, fm);
+        return;
+    }
+
+    r->af    = t->af;
+    r->proto = t->proto;
+    r->saddr = t->saddr;
+    r->daddr = t->daddr;
+    r->sport = t->sport;
+    r->dport = t->dport;
+    r->cid   = rte_lcore_id();
+
+#ifdef CONFIG_DPVS_IPVS_DEBUG
+    dp_vs_redirect_show(r, "init");
+#endif
+}
+
+/**
+ * try lookup dp_vs_cr_tab{} by packet tuple
+ *
+ *  <af, proto, saddr, sport, daddr, dport>.
+ *
+ * return r if found or NULL if not exist.
+ */
+struct dp_vs_redirect *
+dp_vs_redirect_get(int af, uint16_t proto,
+    const union inet_addr *saddr, const union inet_addr *daddr,
+    uint16_t sport, uint16_t dport)
+{
+    uint32_t hash;
+    struct dp_vs_redirect *r;
+
+    hash = dp_vs_conn_hashkey(af, saddr, sport, daddr, dport, DPVS_CR_TBL_MASK);
+
+    rte_spinlock_lock(&dp_vs_cr_lock[hash]);
+    list_for_each_entry(r, &dp_vs_cr_tab[hash], list) {
+        if (r->af == af
+            && r->proto == proto
+            && r->sport == sport
+            && r->dport == dport
+            && inet_addr_equal(af, &r->saddr, saddr)
+            && inet_addr_equal(af, &r->daddr, daddr)) {
+            goto found;
+        }
+    }
+    rte_spinlock_unlock(&dp_vs_cr_lock[hash]);
+
+    return NULL;
+
+found:
+    rte_spinlock_unlock(&dp_vs_cr_lock[hash]);
+
+#ifdef CONFIG_DPVS_IPVS_DEBUG
+    dp_vs_redirect_show(r, "get");
+#endif
+
+    return r;
+}
+
+/**
+ * Forward the packet to the found redirect owner core.
+ */
+int dp_vs_redirect_pkt(struct rte_mbuf *mbuf, lcoreid_t peer_cid)
+{
+    lcoreid_t cid = rte_lcore_id();
+    int ret;
+
+    ret = rte_ring_enqueue(dp_vs_redirect_ring[peer_cid][cid], mbuf);
+    if (ret < 0) {
+        RTE_LOG(ERR, IPVS,
+                "%s: [%d] failed to enqueue mbuf to redirect_ring[%d][%d]\n",
+                __func__, cid, peer_cid, cid);
+        return INET_DROP;
+    }
+
+#ifdef CONFIG_DPVS_IPVS_DEBUG
+    RTE_LOG(DEBUG, IPVS,
+            "%s: [%d] enqueued mbuf to redirect_ring[%d][%d]\n",
+            __func__, cid, peer_cid, cid);
+#endif
+
+    return INET_STOLEN;
+}
+
+void dp_vs_redirect_ring_proc(struct netif_queue_conf *qconf, lcoreid_t cid)
+{
+    struct rte_mbuf *mbufs[NETIF_MAX_PKT_BURST];
+    uint16_t nb_rb;
+    lcoreid_t peer_cid;
+
+    cid = rte_lcore_id();
+
+    for (peer_cid = 0; peer_cid < DPVS_MAX_LCORE; peer_cid++) {
+        if (dp_vs_redirect_ring[cid][peer_cid]) {
+            nb_rb = rte_ring_dequeue_burst(dp_vs_redirect_ring[cid][peer_cid],
+                                           (void**)mbufs,
+                                           NETIF_MAX_PKT_BURST, NULL);
+            if (nb_rb > 0) {
+                lcore_process_packets(qconf, mbufs, cid, nb_rb, 1);
+            }
+        }
+    }
+}
+
+static int dp_vs_redirect_table_create(void)
+{
+    int i;
+    char poolname[32];
+
+    /*
+     * allocate redirect cache on each NUMA socket and its size is
+     * same as conn_pool_size
+     */
+    for (i = 0; i < get_numa_nodes(); i++) {
+        snprintf(poolname, sizeof(poolname), "dp_vs_redirect_%d", i);
+        dp_vs_cr_cache[i] =
+            rte_mempool_create(poolname,
+                               dp_vs_conn_pool_size(),
+                               sizeof(struct dp_vs_redirect),
+                               dp_vs_conn_pool_cache_size(),
+                               0, NULL, NULL, NULL, NULL,
+                               i, 0);
+        if (!dp_vs_cr_cache[i]) {
+            return EDPVS_NOMEM;
+        }
+    }
+
+    /* allocate the global redirect hash table, per socket? */
+    dp_vs_cr_tab =
+        rte_malloc_socket(NULL, sizeof(struct list_head ) * DPVS_CR_TBL_SIZE,
+                          RTE_CACHE_LINE_SIZE, rte_socket_id());
+    if (!dp_vs_cr_tab) {
+        return EDPVS_NOMEM;
+    }
+
+    /* init the global redirect hash table */
+    for (i = 0; i < DPVS_CR_TBL_SIZE; i++) {
+        INIT_LIST_HEAD(&dp_vs_cr_tab[i]);
+        rte_spinlock_init(&dp_vs_cr_lock[i]);
+    }
+
+    return EDPVS_OK;
+}
+
+static void dp_vs_redirect_table_free(void)
+{
+    int i;
+
+    for (i = 0; i < get_numa_nodes(); i++) {
+        rte_mempool_free(dp_vs_cr_cache[i]);
+    }
+
+    /* release the global redirect hash table */
+    rte_free(dp_vs_cr_tab);
+}
+
+/*
+ * Each lcore allocates redirect rings with the other lcores espectively.
+ */
+static int dp_vs_redirect_ring_create(void)
+{
+    char name_buf[RTE_RING_NAMESIZE];
+    int socket_id;
+    lcoreid_t cid, peer_cid;
+
+    socket_id = rte_socket_id();
+
+    for (cid = 0; cid < DPVS_MAX_LCORE; cid++) {
+        if (cid == rte_get_master_lcore() || !rte_lcore_is_enabled(cid)) {
+            continue;
+        }
+
+        for (peer_cid = 0; peer_cid < DPVS_MAX_LCORE; peer_cid++) {
+            if (!rte_lcore_is_enabled(peer_cid)
+                || peer_cid == rte_get_master_lcore()
+                || cid == peer_cid) {
+                continue;
+            }
+
+            snprintf(name_buf, RTE_RING_NAMESIZE,
+                     "dp_vs_redirect_ring[%d[%d]", cid, peer_cid);
+
+            dp_vs_redirect_ring[cid][peer_cid] =
+                rte_ring_create(name_buf, DPVS_REDIRECT_RING_SIZE, socket_id,
+                                RING_F_SP_ENQ | RING_F_SC_DEQ);
+
+            if (!dp_vs_redirect_ring[cid][peer_cid]) {
+                RTE_LOG(ERR, IPVS,
+                        "%s: failed to create redirect_ring[%d][%d]\n",
+                        __func__, cid, peer_cid);
+                return EDPVS_NOMEM;
+            }
+        }
+    }
+
+    return EDPVS_OK;
+}
+
+static void dp_vs_redirect_ring_free(void)
+{
+    lcoreid_t cid, peer_cid;
+
+    for (cid = 0; cid < DPVS_MAX_LCORE; cid++) {
+        for (peer_cid = 0; peer_cid < DPVS_MAX_LCORE; peer_cid++) {
+            rte_ring_free(dp_vs_redirect_ring[cid][peer_cid]);
+        }
+    }
+}
+
+int dp_vs_redirects_init(void)
+{
+    int err;
+
+    err = dp_vs_redirect_ring_create();
+    if (err != EDPVS_OK) {
+        return err;
+    }
+
+    return dp_vs_redirect_table_create();
+}
+
+int dp_vs_redirects_term(void)
+{
+    dp_vs_redirect_ring_free();
+    dp_vs_redirect_table_free();
+
+    return EDPVS_OK;
+}

--- a/src/netif.c
+++ b/src/netif.c
@@ -41,7 +41,7 @@
 #include <rte_arp.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-
+#include <ipvs/redirect.h>
 
 #define NETIF_PKTPOOL_NB_MBUF_DEF   65535
 #define NETIF_PKTPOOL_NB_MBUF_MIN   1023
@@ -320,7 +320,7 @@ static void rss_handler(vector_t tokens)
             struct port_conf_stream, port_list_node);
 
     assert(str);
-    if (!strcmp(str, "all") || !strcmp(str, "ip") || !strcmp(str, "tcp") || !strcmp(str, "udp") 
+    if (!strcmp(str, "all") || !strcmp(str, "ip") || !strcmp(str, "tcp") || !strcmp(str, "udp")
             || !strcmp(str, "sctp") || !strcmp(str, "ether") || !strcmp(str, "port") || !strcmp(str, "tunnel")
             || (strstr(str, "|") && str[0] != '|')) {
         RTE_LOG(INFO, NETIF, "%s:rss = %s\n", current_device->name, str);
@@ -1062,7 +1062,7 @@ static struct pkt_type *pkt_type_get(uint16_t type, struct netif_port *port)
 }
 
 /****************************************** lcore job *********************************************/
-/* Note: lockless, lcore_job can only be register on initialization stage and 
+/* Note: lockless, lcore_job can only be register on initialization stage and
  *       unregistered on cleanup stage.
  */
 struct list_head netif_lcore_jobs[NETIF_LCORE_JOB_TYPE_MAX];
@@ -1224,6 +1224,11 @@ static void config_lcores(struct list_head *worker_list)
 /* fast searching tables */
 lcoreid_t lcore2index[DPVS_MAX_LCORE];
 portid_t port2index[DPVS_MAX_LCORE][NETIF_MAX_PORTS];
+
+bool netif_lcore_is_idle(lcoreid_t cid)
+{
+    return (lcore_conf[lcore2index[cid]].nports == 0) ? true : false;
+}
 
 static void lcore_index_init(void)
 {
@@ -2110,7 +2115,7 @@ int netif_hard_xmit(struct rte_mbuf *mbuf, struct netif_port *dev)
         (lcore_conf[lcore2index[cid]].pqs[port2index[cid][pid]].ntxq);
     //RTE_LOG(DEBUG, NETIF, "tx-queue hash(%x) = %d\n", ((uint32_t)mbuf->buf_physaddr) >> 8, qindex);
     txq = &lcore_conf[lcore2index[cid]].pqs[port2index[cid][pid]].txqs[qindex];
-    
+
     if (unlikely(txq->len == NETIF_MAX_PKT_BURST)) {
         netif_tx_burst(cid, pid, qindex);
         txq->len = 0;
@@ -2161,7 +2166,7 @@ static inline eth_type_t eth_type_parse(const struct ether_hdr *eth_hdr,
         else
             return ETH_PKT_MULTICAST;
     }
-    
+
     return ETH_PKT_OTHERHOST;
 }
 
@@ -2287,10 +2292,10 @@ static int netif_arp_ring_init(void)
     return EDPVS_OK;
 }
 
-static void lcore_process_packets(struct netif_queue_conf *qconf, struct rte_mbuf **mbufs,
+void lcore_process_packets(struct netif_queue_conf *qconf, struct rte_mbuf **mbufs,
                       lcoreid_t cid, uint16_t count, bool pkts_from_ring)
 {
-    int i, t;
+    int i, t = 0;
     struct ether_hdr *eth_hdr;
     struct rte_mbuf *mbuf_copied = NULL;
 
@@ -2390,6 +2395,11 @@ static void lcore_process_arp_ring(struct netif_queue_conf *qconf, lcoreid_t cid
     }
 }
 
+static void lcore_process_redirect_ring(struct netif_queue_conf *qconf, lcoreid_t cid)
+{
+    dp_vs_redirect_ring_proc(qconf, cid);
+}
+
 static void lcore_job_recv_fwd(void *arg)
 {
     int i, j;
@@ -2408,6 +2418,7 @@ static void lcore_job_recv_fwd(void *arg)
             qconf = &lcore_conf[lcore2index[cid]].pqs[i].rxqs[j];
 
             lcore_process_arp_ring(qconf, cid);
+            lcore_process_redirect_ring(qconf, cid);
             qconf->len = netif_rx_burst(pid, qconf);
 
             lcore_stats_burst(&lcore_stats[cid], qconf->len);
@@ -2506,7 +2517,7 @@ static void netif_lcore_init(void)
     for (ii = 0; ii < NETIF_JOB_COUNT; ii++) {
         res = netif_lcore_loop_job_register(&netif_jobs[ii]);
         if (res < 0) {
-            rte_exit(EXIT_FAILURE, 
+            rte_exit(EXIT_FAILURE,
                     "[%s] Fail to register netif lcore jobs, exiting ...\n", __func__);
             break;
         }
@@ -2552,10 +2563,10 @@ static inline void free_mbufs(struct rte_mbuf **pkts, unsigned num)
     for (i = 0; i < num; i++) {
         rte_pktmbuf_free(pkts[i]);
         pkts[i] = NULL;
-    }    
+    }
 }
 
-static void kni_ingress(struct rte_mbuf *mbuf, struct netif_port *dev, 
+static void kni_ingress(struct rte_mbuf *mbuf, struct netif_port *dev,
                         struct netif_queue_conf *qconf)
 {
     unsigned pkt_num;
@@ -2573,8 +2584,8 @@ static void kni_ingress(struct rte_mbuf *mbuf, struct netif_port *dev,
     }
 
     /* VLAN device cannot be scheduled by kni_send2kern_loop */
-    if ((dev->type == PORT_TYPE_VLAN && qconf->kni_len > 0)||
-            unlikely(qconf->kni_len == NETIF_MAX_PKT_BURST)) {
+    if ((dev->type == PORT_TYPE_VLAN && qconf->kni_len > 0) ||
+        unlikely(qconf->kni_len == NETIF_MAX_PKT_BURST)) {
         rte_spinlock_lock(&kni_lock);
         pkt_num = rte_kni_tx_burst(dev->kni.kni, qconf->kni_mbufs, qconf->kni_len);
         rte_spinlock_unlock(&kni_lock);
@@ -2592,7 +2603,7 @@ static void kni_send2kern_loop(uint8_t port_id, struct netif_queue_conf *qconf)
 {
     struct netif_port *dev;
     unsigned pkt_num;
-   
+
     dev = netif_port_get(port_id);
 
     if (qconf->kni_len > 0) {
@@ -3040,7 +3051,7 @@ static struct netif_port* netif_rte_port_alloc(portid_t id, int nrxq,
     port->hw_header_len = sizeof(struct ether_hdr);
     if (port->socket == SOCKET_ID_ANY)
         port->socket = rte_socket_id();
-    port->mbuf_pool = pktmbuf_pool[port->socket]; 
+    port->mbuf_pool = pktmbuf_pool[port->socket];
     rte_eth_macaddr_get((uint8_t)id, &port->addr);
     rte_eth_dev_get_mtu((uint8_t)id, &port->mtu);
     rte_eth_dev_info_get((uint8_t)id, &port->dev_info);
@@ -3125,7 +3136,7 @@ int netif_get_queue(struct netif_port *port, lcoreid_t cid, queueid_t *qid)
     if (++idx > IDX_MAX)
         idx = 0;
 
-    *qid = qconf->rxqs[idx % qconf->nrxq].id; 
+    *qid = qconf->rxqs[idx % qconf->nrxq].id;
     return EDPVS_OK;
 }
 
@@ -3166,7 +3177,7 @@ int netif_get_stats(struct netif_port *dev, struct rte_eth_stats *stats)
     return EDPVS_OK;
 }
 
-int netif_fdir_filter_set(struct netif_port *port, enum rte_filter_op opcode, 
+int netif_fdir_filter_set(struct netif_port *port, enum rte_filter_op opcode,
                           const struct rte_eth_fdir_filter *fdir_flt)
 {
     assert(port && port->netif_ops);
@@ -3487,7 +3498,7 @@ int netif_port_start(struct netif_port *port)
     if (port->ntxq > 0) {
         for (qid = 0; qid < port->ntxq; qid++) {
             memcpy(&txconf, &port->dev_info.default_txconf, sizeof(struct rte_eth_txconf));
-            if (port->dev_conf.rxmode.jumbo_frame 
+            if (port->dev_conf.rxmode.jumbo_frame
                     || (port->flag & NETIF_PORT_FLAG_TX_IP_CSUM_OFFLOAD)
                     || (port->flag & NETIF_PORT_FLAG_TX_UDP_CSUM_OFFLOAD)
                     || (port->flag & NETIF_PORT_FLAG_TX_TCP_CSUM_OFFLOAD))
@@ -3515,20 +3526,20 @@ int netif_port_start(struct netif_port *port)
     // build port-queue-lcore mapping array
     build_port_queue_lcore_map();
 
-    // start the device 
+    // start the device
     ret = rte_eth_dev_start(port->id);
     if (ret < 0) {
         RTE_LOG(ERR, NETIF, "%s: fail to start %s\n", __func__, port->name);
         return EDPVS_DPDKAPIFAIL;
     }
 
-    // wait the device link up 
+    // wait the device link up
     RTE_LOG(INFO, NETIF, "Waiting for %s link up, be patient ...\n", port->name);
     for (ii = 0; ii < wait_link_up_msecs; ii++) {
         rte_eth_link_get_nowait(port->id, &link);
         if (link.link_status) {
             RTE_LOG(INFO, NETIF, ">> %s: link up - speed %u Mbps - %s\n",
-                    port->name, (unsigned)link.link_speed, 
+                    port->name, (unsigned)link.link_speed,
                     (link.link_duplex == ETH_LINK_FULL_DUPLEX) ?
                     "full-duplex" : "half-duplex");
             break;


### PR DESCRIPTION
Since IPv6 flow director is not well-supported by ixgbe driver and only one
single local IPv6 address can be set in "signature" mode, the below solution of
connection redirect provides the way to support IPv6 packet processing with
multiple local IPv6 addresses configured in "signature" mode.

During the system boots up, the below resource is pre-allcoated.
- Per-socket based connection redirect cache;
- Per-socket based global connection redirect hash table;
- Each lcore allocates its respective packet redirect rings for each other
  lcores to avoid the contention of enqueuing the packets in the same ring.

o When a connection is created and hashed in nat-mode, the related redirect
  is allocated and hashed accordingly.

o When a connection expires to be unhashed and freed in nat-mode, the related
  redirect is unhashed and freed accordingly.

o In the stage of PRE_ROUTING, if the packet does not match any dpvs connection,
  then check if it matches any connection redirect entry. If matched, enqueue
  the packet into the packet redirect ring of the rediret owner core; otherwise,
  continue to process it on the current lcore.

o Within lcore_job_recv_fwd(), add the task of dequeuing the packets from all
  the packet redirect rings owned by the current lcore and process them
  accordingly.