### PR TITLE
fix bug:

### DIFF
--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -592,7 +592,7 @@ int ipv4_xmit(struct rte_mbuf *mbuf, const struct flow4 *fl4)
 
     /* output route decision: out-dev, source address, ... */
     rt = route4_output(fl4);
-    if (!rt) {
+    if (!rt || !(rt->flag & RTF_FORWARD)) {
         rte_pktmbuf_free(mbuf);
         IP4_INC_STATS(outnoroutes);
         return EDPVS_NOROUTE;

--- a/src/ipvs/ip_vs_core.c
+++ b/src/ipvs/ip_vs_core.c
@@ -495,11 +495,12 @@ static int dp_vs_in_icmp(struct rte_mbuf *mbuf, int *related)
     dp_vs_fill_iphdr(AF_INET, mbuf, &dciph);
 
     conn = prot->conn_lookup(prot, &dciph, mbuf, &dir, true, &drop);
-    if (!conn)
-        return INET_ACCEPT;
 
     /* recover mbuf.data_off to outer IP header. */
     rte_pktmbuf_prepend(mbuf, off);
+
+    if (!conn)
+        return INET_ACCEPT;
 
     /* so the ICMP is related to existing conn */
     *related = 1;


### PR DESCRIPTION
icmp mbuf relate to conn adj but not prepend