### PR TITLE
fix bug:

### DIFF
--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -532,7 +532,8 @@ int ipv4_xmit(struct rte_mbuf *mbuf, const struct flow4 *fl4)
 
     /* output route decision: out-dev, source address, ... */
     rt = route4_output(fl4);
-    if (!rt) {
+    /* not support loopback */
+    if (!rt || !(rt->flag & RTF_FORWARD)) {
         rte_pktmbuf_free(mbuf);
         IP4_INC_STATS(outnoroutes);
         return EDPVS_NOROUTE;

--- a/src/ipvs/ip_vs_core.c
+++ b/src/ipvs/ip_vs_core.c
@@ -715,11 +715,11 @@ static int __dp_vs_in_icmp4(struct rte_mbuf *mbuf, int *related)
         return dp_vs_redirect_pkt(mbuf, peer_cid);
     }
 
-    if (!conn)
-        return INET_ACCEPT;
-
     /* recover mbuf.data_off to outer IP header. */
     rte_pktmbuf_prepend(mbuf, off);
+
+    if (!conn)
+        return INET_ACCEPT;
 
     /* so the ICMP is related to existing conn */
     *related = 1;
@@ -858,11 +858,11 @@ static int __dp_vs_in_icmp6(struct rte_mbuf *mbuf, int *related)
         return dp_vs_redirect_pkt(mbuf, peer_cid);
     }
 
-    if (!conn)
-        return INET_ACCEPT;
-
     /* recover mbuf.data_off to outer IP header. */
     rte_pktmbuf_prepend(mbuf, off);
+
+    if (!conn)
+        return INET_ACCEPT;
 
     /* so the ICMP is related to existing conn */
     *related = 1;


### PR DESCRIPTION
conn related icmp mbuf adj but not prepend，this may cause icmp error be sent in ipv4_forward