### PR TITLE
DPVS changes for DPDK 18.11.0

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -239,7 +239,7 @@ int main(int argc, char *argv[])
                  dpvs_strerror(err));
 
     /* config and start all available dpdk ports */
-    nports = rte_eth_dev_count();
+    nports = rte_eth_dev_count_avail();
     for (pid = 0; pid < nports; pid++) {
         dev = netif_port_get(pid);
         if (!dev) {

--- a/src/netif.c
+++ b/src/netif.c
@@ -1397,7 +1397,7 @@ static int check_lcore_conf(int lcores, const struct netif_lcore_conf *lcore_con
     queueid_t qid;
     struct netif_lcore_conf mark;
     memset(&mark, 0, sizeof(mark));
-    nports = rte_eth_dev_count();
+    nports = rte_eth_dev_count_avail();
     while (lcore_conf[i].nports > 0)
     {
         if (lcore2index[lcore_conf[i].id] != i) {
@@ -2440,7 +2440,7 @@ static void lcore_job_xmit(void *args)
     for (i = 0; i < lcore_conf[lcore2index[cid]].nports; i++) {
         pid = lcore_conf[lcore2index[cid]].pqs[i].id;
 #ifdef CONFIG_DPVS_NETIF_DEBUG
-        if (unlikely(pid >= rte_eth_dev_count())) {
+        if (unlikely(pid >= rte_eth_dev_count_avail())) {
             RTE_LOG(DEBUG, NETIF, "[%s] No enough NICs\n", __func__);
             continue;
         }
@@ -2879,13 +2879,21 @@ static int dpdk_set_mc_list(struct netif_port *dev)
 {
     struct ether_addr addrs[NETIF_MAX_HWADDR];
     int err;
+    int ret = 0;
     size_t naddr = NELEMS(addrs);
 
     err = __netif_mc_dump(dev, addrs, &naddr);
     if (err != EDPVS_OK)
         return err;
 
-    return rte_eth_dev_set_mc_addr_list((uint8_t)dev->id, addrs, naddr);
+    ret = rte_eth_dev_set_mc_addr_list((uint8_t)dev->id, addrs, naddr);
+    if (ret == -ENOTSUP) {
+        /* If nic doesn't support to set multicast filter, enable all. */
+        rte_eth_allmulticast_enable(dev->id);
+        ret = EDPVS_OK;
+    }
+
+    return ret;
 }
 
 static int dpdk_filter_supported(struct netif_port *dev, enum rte_filter_type fltype)
@@ -2971,13 +2979,9 @@ static inline void setup_dev_of_flags(struct netif_port *port)
 
     if (port->dev_info.tx_offload_capa & DEV_TX_OFFLOAD_TCP_CKSUM)
         port->flag |= NETIF_PORT_FLAG_TX_TCP_CSUM_OFFLOAD;
-    else
-        port->dev_info.default_txconf.txq_flags |= ETH_TXQ_FLAGS_NOXSUMTCP;
 
     if (port->dev_info.tx_offload_capa & DEV_TX_OFFLOAD_UDP_CKSUM)
         port->flag |= NETIF_PORT_FLAG_TX_UDP_CSUM_OFFLOAD;
-    else
-        port->dev_info.default_txconf.txq_flags |= ETH_TXQ_FLAGS_NOXSUMUDP;
 
     /* FIXME: may be a bug in dev_info get for virtio device,
      *        set the txq_of_flags manually for this type device */
@@ -3005,7 +3009,7 @@ static inline void setup_dev_of_flags(struct netif_port *port)
     /* rx offload conf and flags */
     if (port->dev_info.rx_offload_capa & DEV_RX_OFFLOAD_VLAN_STRIP) {
         port->flag |= NETIF_PORT_FLAG_RX_VLAN_STRIP_OFFLOAD;
-        port->dev_conf.rxmode.hw_vlan_strip = 1;
+        port->dev_conf.rxmode.offloads |= DEV_RX_OFFLOAD_VLAN_STRIP;
     }
     if (port->dev_info.rx_offload_capa & DEV_RX_OFFLOAD_IPV4_CKSUM)
         port->flag |= NETIF_PORT_FLAG_RX_IP_CSUM_OFFLOAD;
@@ -3285,6 +3289,22 @@ static int rss_resolve_proc(char *rss)
     return rss_value;
 }
 
+/* check and adapt device rss hash function */
+static void adapt_device_rss_hf(portid_t port_id, uint64_t *rss_hf)
+{
+    struct rte_eth_dev_info dev_info;
+
+    rte_eth_dev_info_get(port_id, &dev_info);
+    if ((dev_info.flow_type_rss_offloads | *rss_hf) !=
+        dev_info.flow_type_rss_offloads) {
+        RTE_LOG(WARNING, NETIF,
+                "Ethdev port_id=%u invalid rss_hf: 0x%"PRIx64", valid value: 0x%"PRIx64"\n",
+                port_id, *rss_hf, dev_info.flow_type_rss_offloads);
+        /* mask the unsupported rss_hf */
+        *rss_hf &= dev_info.flow_type_rss_offloads;
+    }
+}
+
 /* fill in rx/tx queue configurations, including queue number,
  * decriptor number, bonding device's rss */
 static void fill_port_config(struct netif_port *port, char *promisc_on)
@@ -3329,6 +3349,9 @@ static void fill_port_config(struct netif_port *port, char *promisc_on)
         port->dev_conf.fdir_conf.mode = cfg_stream->fdir_mode;
         port->dev_conf.fdir_conf.pballoc = cfg_stream->fdir_pballoc;
         port->dev_conf.fdir_conf.status = cfg_stream->fdir_status;
+
+        /* need to adapt configured rss_hf as driver supported RSS offload types are different. */
+        adapt_device_rss_hf(port->id, &port->dev_conf.rx_adv_conf.rss_conf.rss_hf);
 
         if (cfg_stream->rx_queue_nb > 0 && port->nrxq > cfg_stream->rx_queue_nb) {
             RTE_LOG(WARNING, NETIF, "%s: rx-queues(%d) configured in workers != "
@@ -3475,6 +3498,13 @@ int netif_port_start(struct netif_port *port)
     // device configure
     if ((ret = netif_port_fdir_dstport_mask_set(port)) != EDPVS_OK)
         return ret;
+
+    if (port->flag & NETIF_PORT_FLAG_TX_IP_CSUM_OFFLOAD)
+        port->dev_conf.txmode.offloads |= DEV_TX_OFFLOAD_IPV4_CKSUM;
+    if (port->flag & NETIF_PORT_FLAG_TX_UDP_CSUM_OFFLOAD)
+        port->dev_conf.txmode.offloads |= DEV_TX_OFFLOAD_UDP_CKSUM;
+    if (port->flag & NETIF_PORT_FLAG_TX_TCP_CSUM_OFFLOAD)
+        port->dev_conf.txmode.offloads |= DEV_TX_OFFLOAD_TCP_CKSUM;
     ret = rte_eth_dev_configure(port->id, port->nrxq, port->ntxq, &port->dev_conf);
     if (ret < 0 ) {
         RTE_LOG(ERR, NETIF, "%s: fail to config %s\n", __func__, port->name);
@@ -3498,11 +3528,6 @@ int netif_port_start(struct netif_port *port)
     if (port->ntxq > 0) {
         for (qid = 0; qid < port->ntxq; qid++) {
             memcpy(&txconf, &port->dev_info.default_txconf, sizeof(struct rte_eth_txconf));
-            if (port->dev_conf.rxmode.jumbo_frame
-                    || (port->flag & NETIF_PORT_FLAG_TX_IP_CSUM_OFFLOAD)
-                    || (port->flag & NETIF_PORT_FLAG_TX_UDP_CSUM_OFFLOAD)
-                    || (port->flag & NETIF_PORT_FLAG_TX_TCP_CSUM_OFFLOAD))
-                txconf.txq_flags = 0;
             ret = rte_eth_tx_queue_setup(port->id, qid, port->txq_desc_nb,
                     port->socket, &txconf);
             if (ret < 0) {
@@ -3735,11 +3760,7 @@ static struct rte_eth_conf default_port_conf = {
         .mq_mode        = ETH_MQ_RX_RSS,
         .max_rx_pkt_len = ETHER_MAX_LEN,
         .split_hdr_size = 0,
-        .header_split   = 0,
-        .hw_ip_checksum = 1,
-        .hw_vlan_filter = 0,
-        .jumbo_frame    = 0,
-        .hw_strip_crc   = 0,
+        .offloads = DEV_RX_OFFLOAD_IPV4_CKSUM,
     },
     .rx_adv_conf = {
         .rss_conf = {
@@ -3875,7 +3896,7 @@ inline static void netif_port_init(const struct rte_eth_conf *conf)
     struct rte_eth_conf this_eth_conf;
     char *kni_name;
 
-    nports = rte_eth_dev_count();
+    nports = rte_eth_dev_count_avail();
     if (nports <= 0)
         rte_exit(EXIT_FAILURE, "No dpdk ports found!\n"
                 "Possibly nic or driver is not dpdk-compatible.\n");
@@ -4102,7 +4123,7 @@ int netif_virtual_devices_add(void)
     }
 #endif
 
-    phy_pid_end = rte_eth_dev_count();
+    phy_pid_end = rte_eth_dev_count_avail();
 
     port_id_end = max(port_id_end, phy_pid_end);
     /* set bond_pid_offset before create bonding device */
@@ -4152,7 +4173,7 @@ int netif_virtual_devices_add(void)
     }
 
     if (!list_empty(&bond_list)) {
-        bond_pid_end = rte_eth_dev_count();
+        bond_pid_end = rte_eth_dev_count_avail();
 
         port_id_end = max(port_id_end, bond_pid_end);
         RTE_LOG(INFO, NETIF, "bonding device port id range: [%d, %d)\n",
@@ -4507,12 +4528,18 @@ static int get_port_basic(struct netif_port *port, void **out, size_t *out_len)
 static inline void copy_dev_info(struct netif_nic_dev_get *get,
         const struct rte_eth_dev_info *dev_info)
 {
-    if (dev_info->pci_dev)
-        snprintf(get->pci_addr, sizeof(get->pci_addr), "%04x:%02x:%02x:%0x",
-                dev_info->pci_dev->addr.domain,
-                dev_info->pci_dev->addr.bus,
-                dev_info->pci_dev->addr.devid,
-                dev_info->pci_dev->addr.function);
+    if (dev_info->device) {
+        const struct rte_bus *bus = NULL;
+        bus = rte_bus_find_by_device(dev_info->device);
+        if (bus && !strcmp(bus->name, "pci")) {
+            const struct rte_pci_device *pci_dev = RTE_DEV_TO_PCI(dev_info->device);
+            snprintf(get->pci_addr, sizeof(get->pci_addr), "%04x:%02x:%02x:%0x",
+                     pci_dev->addr.domain,
+                     pci_dev->addr.bus,
+                     pci_dev->addr.devid,
+                     pci_dev->addr.function);
+        }
+    }
     if (dev_info->driver_name)
         strncpy(get->driver_name, dev_info->driver_name, sizeof(get->driver_name));
     get->if_index = dev_info->if_index;


### PR DESCRIPTION
Some initial changes for DPDK 18.11.0. Compared to DPDK 17.11.2, changes are listed below:
1. API change: rte_eth_dev_count() -> rte_eth_dev_count_avail().
2. In DPDK 18.08 release, ethdev: The old offload API is removed:
       Rx per-port rte_eth_conf.rxmode.[bit-fields]
       Tx per-queue rte_eth_txconf.txq_flags
       ETH_TXQ_FLAGS_NO*
   The transition bits are removed:
       rte_eth_conf.rxmode.ignore_offload_bitfield
       ETH_TXQ_FLAGS_IGNORE
3. In DPDK 18.05, rss_hf check is added. So adapt_device_rss_hf() is added.
   https://github.com/DPDK/dpdk/commit/8863a1fbfc66f762f70eb486431c23cc55f2cc3c
4. The following warning is presented in DPVS log.
   "Kni: kni_add_dev: fail to set mac 6C:92:BF:A1:ED:20 for eth0: Timer expired"
   It doesn't matter as function works well. This log printed because compared to DPDK 17.11.2,
   kni_net_set_mac callback function in DPDK 18.11 adds kni_net_process_request().
   kni_net_process_request() calls wait_event_interruptible_timeout() which returns Timeout err code.
5. When install rte_kni kernel module, parameter "carrier=on" should be added.
   This is because DPDK 18.11 updated the KNI kernel module with a new kernel module parameter,
   carrier=[on|off] to allow the user to control the default carrier state of the KNI kernel network interfaces.
   Actually, rte_kni_update_link API should be used, but it's an experimental API. See release note for detail.