### PR TITLE
sa_pool: add a sa_pool option using laddr to map lcore except the lport-mask mode

### DIFF
--- a/conf/dpvs.conf.sample
+++ b/conf/dpvs.conf.sample
@@ -319,5 +319,6 @@ ipvs_defs {
 
 ! sa_pool config
 sa_pool {
+    pool_mode        laddr_lcore_mapping
     pool_hash_size   16
 }

--- a/include/sa_pool.h
+++ b/include/sa_pool.h
@@ -42,6 +42,11 @@
 #ifndef __DPVS_SA_POOL__
 #define __DPVS_SA_POOL__
 
+enum {
+    LADDR_LCORE_MAPPING_POOL_MODE,
+    LPORT_LCORE_MAPPING_POOL_MODE,
+};
+
 struct sa_pool_stats {
     uint32_t used_cnt;
     uint32_t free_cnt;


### PR DESCRIPTION
sa_pool: add a sa_pool option using laddr to map lcore except the lport-mask mode

NOTICE:
number of laddrs should be greater or equal to number of slave lcores.
Or, some slave lcores will have no laddr causing FNAT fowarding failed in
those slave lcores.