### PR TITLE
ndisc/neigh: sync the neighbour entry to other cores once it is created.

### DIFF
--- a/src/ipv6/ndisc.c
+++ b/src/ipv6/ndisc.c
@@ -464,7 +464,7 @@ static int ndisc_recv_na(struct rte_mbuf *mbuf, struct netif_port *dev)
     }
 
     /* notice: override flag ignored */
-    hashkey = neigh_hashkey(AF_INET6, (union inet_addr *)saddr, dev);
+    hashkey = neigh_hashkey(AF_INET6, (union inet_addr *)&msg->target, dev);
     neigh = neigh_lookup_entry(AF_INET6, (union inet_addr *)&msg->target, dev, hashkey);
     if (neigh && !(neigh->flag & NEIGHBOUR_STATIC)) {
         neigh_edit(neigh, (struct ether_addr *)lladdr);
@@ -541,4 +541,3 @@ free:
     rte_pktmbuf_free(mbuf);
     return ret;
 }
-


### PR DESCRIPTION
During nat64 test, the below issue is met on IPv6-side (aka wan side).
Provided that dpvs's gateway IPv6 address is  fcbd:dc00:46::1.

1) When the outgoing packet destined to IPv6 client is sent out from dpvs, we
  need to resolve dpvs's gateway mac address. So the below neighbour
  solicitation is sent from dpvs to its IPv6 gateway.

  (:: -> ff02::1:ff00:1) that includes info, "Neighbour Solicitation for
  fcbd:dc00:46::1".

  And the related neighbour entry, E1, (fcbd:dc00:46::1, null mac address, dpdk1) is
  created on core A.

2) The coresponding neighbour advertisement is received on core B.

  (fe80:274:9cff:fe0e:1441 -> ff02::1) that includes info, "Neighbour
  Advertisement fcbd:dc00:46::1 (rtr, ovr) is at 00:74:9c:0e:14:41".

  Since it is received on core B, we have no way to find the previously created
  neighbour entry, E1 which is created on core A.

  So the solution is to sync the neighbour entry to the other cores once it is
  created and we still follow the design of per-lcore neighbour mgmt.

  Additionally, within ndisc_recv_na(), target address, "fcbd:dc00:46::1" should
  be used to find the neighbour entry instead of source-ip address,
  "fe80:274:9cff:fe0e:1441". So the entry, E1 is resolved as below and then
  synced to the other cores.

      (fcbd:dc00:46::1, 00:74:9c:0e:14:41, dpdk1)