### PR TITLE
keepalived: fix crash when remove all RS(s) from virtual service group

### DIFF
--- a/tools/keepalived/keepalived/check/ipwrapper.c
+++ b/tools/keepalived/keepalived/check/ipwrapper.c
@@ -41,6 +41,9 @@ weigh_live_realservers(virtual_server_t * vs)
 	real_server_t *svr;
 	long unsigned count = 0;
 
+	if (LIST_ISEMPTY(vs->rs))
+		return count;
+
 	for (e = LIST_HEAD(vs->rs); e; ELEMENT_NEXT(e)) {
 		svr = ELEMENT_DATA(e);
 		if (ISALIVE(svr))


### PR DESCRIPTION
```bash
Program terminated with signal 11, Segmentation fault.
#0  0x000000000040fb72 in weigh_live_realservers (vs=vs@entry=0xca0470) at ipwrapper.c:47
47	ipwrapper.c: No such file or directory.
Missing separate debuginfos, use: debuginfo-install glibc-2.17-196.el7.x86_64 keyutils-libs-1.5.8-3.el7.x86_64 krb5-libs-1.15.1-8.el7.x86_64 libcom_err-1.42.9-10.el7.x86_64 libgcc-4.8.5-16.el7_4.1.x86_64 libselinux-2.5-11.el7.x86_64 nss-softokn-freebl-3.28.3-8.el7_4.x86_64 numactl-libs-2.0.9-6.el7_2.x86_64 openssl-libs-1.0.2k-8.el7.x86_64 pcre-8.32-17.el7.x86_64 zlib-1.2.7-17.el7.x86_64
(gdb) bt
#0  0x000000000040fb72 in weigh_live_realservers (vs=vs@entry=0xca0470) at ipwrapper.c:47
#1  update_quorum_state (vs=vs@entry=0xca0470) at ipwrapper.c:327
#2  0x0000000000410016 in init_service_vs (vs=0xca0470) at ipwrapper.c:229
#3  init_services () at ipwrapper.c:246
#4  0x0000000000405745 in start_check () at check_daemon.c:140
#5  0x0000000000405899 in reload_check_thread (thread=<optimized out>) at check_daemon.c:219
#6  0x0000000000422bed in thread_call (thread=0x7ffe6fbcd140) at scheduler.c:761
#7  launch_scheduler () at scheduler.c:784
#8  0x00000000004058dd in start_check_child () at check_daemon.c:318
#9  0x0000000000403107 in start_keepalived () at main.c:80
#10 main (argc=<optimized out>, argv=<optimized out>) at main.c:303
```