### PR TITLE
ipv6: pass into kni the icmpv6 echo reqeust packets destined to vip6.

### DIFF
--- a/src/ipv6/ipv6.c
+++ b/src/ipv6/ipv6.c
@@ -489,8 +489,12 @@ static int ip6_rcv_fin(struct rte_mbuf *mbuf)
     if (rt->rt6_flags & RTF_LOCALIN) {
         return ip6_local_in(mbuf);
     } else if (rt->rt6_flags & RTF_FORWARD) {
-        /* pass multi-/broad-cast to kni */
-        if (etype != ETH_PKT_HOST)
+        /*
+         * pass the packet to kni in the below two cases.
+         * - multi-/broad-cast packets;
+         * - to-host packets when ipv6 forwarding is disabled;
+         */
+        if (etype != ETH_PKT_HOST || !conf_ipv6_forwarding)
             goto kni;
 
         return ip6_forward(mbuf);


### PR DESCRIPTION
o Within nat64 case, the below route is configured within keepalived.conf.

```
  static_routes {
      # wan-side IPv6 gateway
      ::/0 via fcbd:dc00:46::1 dev dpdk1

      # lan-side IPv4 routes
      . . .
  }
```

  When the client ping6 vip6, like fcbd:dc01:1:111::2 configured on dpvs, the
  packet matches the default IPv6 route and then gets dropped becuase IPv6
  forwarding is disabled. So the client fails to ping6 vip6.

  The solution is to pass the to-host packet to kni when ipv6 forwarding is
  disabled.