### PR TITLE
keepalived: fix vrrp process crash and static ipaddress deletion bug

### DIFF
--- a/tools/keepalived/keepalived/vrrp/vrrp_netlink.c
+++ b/tools/keepalived/keepalived/vrrp/vrrp_netlink.c
@@ -492,6 +492,7 @@ netlink_if_link_filter(struct sockaddr_nl *snl, struct nlmsghdr *h)
 
 	/* Fill the interface structure */
 	ifp = (interface_t *) MALLOC(sizeof(interface_t));
+	memset(ifp, 0, sizeof(*ifp));
 	memcpy(ifp->ifname, name, strlen(name));
 	ifp->ifindex = ifi->ifi_index;
 	ifp->mtu = *(int *) RTA_DATA(tb[IFLA_MTU]);


### PR DESCRIPTION
1. vrrp process crash when reload dpvs, this patch check NULL pointer before use strcmp.
2. if_queue is freed by free_interface_queue() when reload keepalived,
   members of if_queue in old_vrrp_data should not be used. Interface index is used instead.