### PR TITLE
neighbour: use IPv6 any address as the source IP of neighbour solicit…

### DIFF
--- a/src/neigh.c
+++ b/src/neigh.c
@@ -431,13 +431,6 @@ static void neigh_state_confirm(struct neighbour_entry *neighbour)
             RTE_LOG(ERR, NEIGHBOUR, "[%s] send arp failed\n", __func__);
         }
     } else if (neighbour->af == AF_INET6) {
-        /*to be continue*/
-        ipv6_addr_copy(&daddr.in6, &neighbour->ip_addr.in6);
-        inet_addr_select(AF_INET6, neighbour->port, &daddr, 0, &saddr);
-
-        if (ipv6_addr_any(&saddr.in6))
-            RTE_LOG(ERR, NEIGHBOUR, "[%s]no source ip\n", __func__);
-
         ndisc_solicit(neighbour, &saddr.in6);
     }
 }
@@ -1079,4 +1072,3 @@ int neigh_term(void)
 
     return EDPVS_OK;
 }
-


### PR DESCRIPTION
…ation.

o Within the case of "ping6 vip6", we prefer processing ICMPv6 echo request in
  userspace instead of passing this request to kernel stack via kni. So we need to
  configure vip6, like fcbd:dc01:1:111::2 on the interface in either of the
  below ways.

  1. Configuration within keepalived.conf
```
  static_ipaddress {
      fcbd:dc01:1:111::2/128 dev dpdk1
  }
```

  2. Configuration via `  # dpip addr add fcbd:dc01:1:111::2/128 dev dpdk1
`
  And then its related to-host route is generated as below and IPv6 default route displayed via "dpip -6 route show"
`        "inet6 fcbd:dc01:1:111::2/128 dev dpdk1 mtu 1500 scope host"`

o With the above configuration, ICMPv6 echo request like below is processed in
  LOCAL_IN path since its dst-IP (aka vip6) matches the above to-host route.

`        fcbd:dc01:1:333::3 -> fcbd:dc01:1:111::2`

  Then dpvs generates the corresponding ICMPv6 echo reply which matches against
  the IPv6 default route configured as below.

```
  static_routes {
      ::/0 via fcbd:dc00:46::1 dev dpdk1  // IPv6 default route

      10.10.127.66/26 dev dpdk0
      10.10.127.0/26 via 10.10.127.65 src 10.10.127.66 dev dpdk0
  }
```
  - IPv6 default route displayed via "dpip -6 route show"
    "inet6 default via fcbd:dc00:46::1 dev dpdk1 mtu 1500 scope global"

  Then we need to resolve the mac address (aka link layer address) for the
  nexthop (gateway) gotten from the default IPv6 route, fcbd:dc00:46::1 in order
  to send out ICMPv6 echo reply.

  So the below neighbour solicitation is sent out from dpvs.

```
  (fcbd:dc01:1:111::2 -> ff02::1:ff00:1) includes the info, "Neighbour
  Solicitation for fcbd:dc00:46::1 from 90:e2:ba:ea:dc:c0".
```

  However the coresponding neighbour advertisement is never received from
  gateway.

  The root cause is that vip6 is selected as the source IP as neighbour
  solicitation according to the nexthop address, fcbd:dc00:46::1. And the
  solution is to use IPv6 any address as the source IP of neighbour solicitation
  as below and the coresponding neighbour advertisement is received consequently.

```
  Neighbour Soliction:
      (:: -> ff02::1:ff00:1) includes the info, "Neighbour Solicitation for
      fcbd:dc00:46::1".
```

  Neighbour Advertisement:
      (fe80::274:9cff:fe0e:1441 -> ff02::1) includes the info, "Neighbour
      Advertisement fcbd:dc00:46::1 (rtr, ovr) is at 00:74:9c:0e:14:41".