### PR TITLE
fix dp_vs_set_svc() use svc after free

### DIFF
--- a/src/ipvs/ip_vs_service.c
+++ b/src/ipvs/ip_vs_service.c
@@ -988,9 +988,8 @@ static int dp_vs_set_svc(sockoptid_t opt, const void *user, size_t len)
             break;
         case DPVS_SO_SET_DEL:
             ret = dp_vs_del_service(svc);
-            // reset svc to avoid use after free
-            svc = NULL;
-            break;
+            // avoid use after free
+            return ret;
         case DPVS_SO_SET_ZERO:
             ret = dp_vs_zero_service(svc);
             break;


### PR DESCRIPTION
if we delete service by call dp_vs_set_svc(opt, user, size) function, it will cause a problem that use sac after free in __dp_vs_del_service(), so we can return ret instead of break.