### PR TITLE
enable bonding mode4 dedicated queue

### DIFF
--- a/include/dpdk.h
+++ b/include/dpdk.h
@@ -55,6 +55,7 @@
 #include <rte_kni.h>
 #include <rte_ip_frag.h>
 #include <rte_eth_bond.h>
+#include <rte_eth_bond_8023ad.h>
 #include "mbuf.h"
 
 typedef uint8_t lcoreid_t;

--- a/src/netif.c
+++ b/src/netif.c
@@ -4104,6 +4104,12 @@ int netif_virtual_devices_add(void)
         RTE_LOG(INFO, NETIF, "create bondig device %s: mode=%d, primary=%s, socket=%d\n",
                 bond_cfg->name, bond_cfg->mode, bond_cfg->primary, socket_id);
         bond_cfg->port_id = pid; /* relate port_id with port_name, used by netif_rte_port_alloc */
+        if (bond_cfg->mode == BONDING_MODE_8023AD) {
+            if (!rte_eth_bond_8023ad_dedicated_queues_enable(bond_cfg->port_id))
+            {
+                RTE_LOG(INFO, NETIF, "bonding mode4 dedicated queues enable failed!\n");
+            }
+        }
     }
 
     if (!list_empty(&bond_list)) {


### PR DESCRIPTION
polling定时器中仅把LACP包丢进发送队列,只有当业务层有数据时才会触发burst函数，真正将发送队列中的LACP包发送给交换机。
使能dedicated_queues，polling定时器会直接发送LACP报文。
