### PR TITLE
ipv4: fix OSPF IP fragmentation problem

### DIFF
--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -474,6 +474,9 @@ static int ipv4_rcv(struct rte_mbuf *mbuf, struct netif_port *port)
     ip4_dump_hdr(iph, mbuf->port);
 #endif
 
+    if (unlikely(iph->next_proto_id == IPPROTO_OSPF))
+            return EDPVS_KNICONTINUE;
+
     return INET_HOOK(INET_HOOK_PRE_ROUTING, mbuf, port, NULL, ipv4_rcv_fin);
 
 csum_error:

--- a/src/ipvs/ip_vs_core.c
+++ b/src/ipvs/ip_vs_core.c
@@ -671,8 +671,7 @@ static int dp_vs_pre_routing(void *priv, struct rte_mbuf *mbuf,
         return INET_ACCEPT;
 
     /* Drop all ip fragment except ospf */
-    if ((af == AF_INET) && ip4_is_frag(ip4_hdr(mbuf))
-            && (iph.proto != IPPROTO_OSPF)) {
+    if ((af == AF_INET) && ip4_is_frag(ip4_hdr(mbuf))) {
         dp_vs_estats_inc(DEFENCE_IP_FRAG_DROP);
         return INET_DROP;
     }


### PR DESCRIPTION
OSPF IP fragments may get lost in 'ip4_defrag' procedure.
Considering DPVS does not process OSPF protocol, we send OSPF
packets to KNI before any inet hooks.