### PR TITLE
Redirect bugfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ all:
 clean:
 	for i in $(SUBDIRS); do $(MAKE) -C $$i clean || exit 1; done
 
+distclean:
+	$(MAKE) -C tools/keepalived distclean || exit 1
+
 install:all
 	-mkdir -p $(INSDIR)
 	for i in $(SUBDIRS); do $(MAKE) -C $$i install || exit 1; done

--- a/src/ipvs/ip_vs_conn.c
+++ b/src/ipvs/ip_vs_conn.c
@@ -663,15 +663,13 @@ struct dp_vs_conn *dp_vs_conn_new(struct rte_mbuf *mbuf,
 
     assert(mbuf && param && dest);
 
-    /* no need to create redirect for the global template connection */
-    if ((flags & DPVS_CONN_F_TEMPLATE) == 0) {
-        new_r = dp_vs_redirect_alloc(dest->fwdmode);
-    }
-
     new = dp_vs_conn_alloc();
     if (unlikely(!new))
-        goto errout_redirect;
+        return NULL;
 
+    /* no need to create redirect for the global template connection */
+    if (likely((flags & DPVS_CONN_F_TEMPLATE) == 0))
+        new_r = dp_vs_redirect_alloc(dest->fwdmode);
     new->redirect = new_r;
 
     /* set proper RS port */
@@ -842,9 +840,8 @@ unbind_laddr:
 unbind_dest:
     conn_unbind_dest(new);
 errout:
-    dp_vs_conn_free(new);
-errout_redirect:
     dp_vs_redirect_free(new);
+    dp_vs_conn_free(new);
     return NULL;
 }
 

--- a/src/ipvs/ip_vs_redirect.c
+++ b/src/ipvs/ip_vs_redirect.c
@@ -17,9 +17,9 @@
  */
 #include "ipvs/redirect.h"
 
-#define DPVS_REDIRECT_RING_SIZE  4096
+#define DPVS_REDIRECT_RING_SIZE  2048
 
-#define DPVS_CR_TBL_BITS   22
+#define DPVS_CR_TBL_BITS   20
 #define DPVS_CR_TBL_SIZE   (1 << DPVS_CR_TBL_BITS)
 #define DPVS_CR_TBL_MASK   (DPVS_CR_TBL_SIZE - 1)
 
@@ -359,12 +359,12 @@ static int dp_vs_redirect_ring_create(void)
     socket_id = rte_socket_id();
 
     for (cid = 0; cid < DPVS_MAX_LCORE; cid++) {
-        if (cid == rte_get_master_lcore() || !rte_lcore_is_enabled(cid)) {
+        if (cid == rte_get_master_lcore() || netif_lcore_is_idle(cid)) {
             continue;
         }
 
         for (peer_cid = 0; peer_cid < DPVS_MAX_LCORE; peer_cid++) {
-            if (!rte_lcore_is_enabled(peer_cid)
+            if (netif_lcore_is_idle(peer_cid)
                 || peer_cid == rte_get_master_lcore()
                 || cid == peer_cid) {
                 continue;

--- a/src/netif.c
+++ b/src/netif.c
@@ -1222,11 +1222,13 @@ static void config_lcores(struct list_head *worker_list)
 }
 
 /* fast searching tables */
-lcoreid_t lcore2index[DPVS_MAX_LCORE];
+lcoreid_t lcore2index[DPVS_MAX_LCORE+1];
 portid_t port2index[DPVS_MAX_LCORE][NETIF_MAX_PORTS];
 
 bool netif_lcore_is_idle(lcoreid_t cid)
 {
+    if (cid > DPVS_MAX_LCORE)
+        return true;
     return (lcore_conf[lcore2index[cid]].nports == 0) ? true : false;
 }
 
@@ -1234,7 +1236,7 @@ static void lcore_index_init(void)
 {
     lcoreid_t ii;
     int tk = 0;
-    for (ii = 0; ii < DPVS_MAX_LCORE; ii++) {
+    for (ii = 0; ii <= DPVS_MAX_LCORE; ii++) {
         if (rte_lcore_is_enabled(ii)) {
             if (likely(tk))
                 lcore2index[ii] = tk - 1;
@@ -1246,7 +1248,7 @@ static void lcore_index_init(void)
     }
 #ifdef CONFIG_DPVS_NETIF_DEBUG
     printf("lcore fast searching table: \n");
-    for (ii = 0; ii < DPVS_MAX_LCORE; ii++)
+    for (ii = 0; ii <= DPVS_MAX_LCORE; ii++)
         printf("lcore2index[%d] = %d\n", ii, lcore2index[ii]);
 #endif
 }


### PR DESCRIPTION
1. 修复服务器CPU数量大于或等于DPVS_MAX_LCORE时，DPVS无法启动的问题
2. 主Makefile增加distclean规则
3. 修复conn分配失败时，redirect 功能导致的 Crash 问题
4. 优化了conn redirect内存使用