### PR TITLE
Patch dpdk-17.11.2 to support rh75

### DIFF
--- a/patch/dpdk-stable-17.11.2/0003-rh75-ndo_change_mtu.patch
+++ b/patch/dpdk-stable-17.11.2/0003-rh75-ndo_change_mtu.patch
@@ -1,0 +1,25 @@
+--- a/lib/librte_eal/linuxapp/kni/compat.h
++++ b/lib/librte_eal/linuxapp/kni/compat.h
+@@ -103,2 +103,8 @@
+
++#if (defined(RHEL_RELEASE_CODE) && \
++       (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7, 5)) && \
++       (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(8, 0)))
++#define ndo_change_mtu ndo_change_mtu_rh74
++#endif
++
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+
+--- a/lib/librte_eal/linuxapp/kni/ethtool/igb/kcompat.h
++++ b/lib/librte_eal/linuxapp/kni/ethtool/igb/kcompat.h
+@@ -3933,4 +3933,10 @@ skb_set_hash(struct sk_buff *skb, __u32
+ #endif
+
++#if (defined(RHEL_RELEASE_CODE) && \
++       (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7, 5)) && \
++       (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(8, 0)))
++#define ndo_change_mtu ndo_change_mtu_rh74
++#endif
++
+ #if ((LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)) || \
+     (SLE_VERSION_CODE && SLE_VERSION_CODE >= SLE_VERSION(12, 3, 0)))


### PR DESCRIPTION
In newer dpdk RH7.5 has been supported and i make a patch to make 17.11.2 to do the same.

Still under testing and it looks good till now.