### PR TITLE
ip_vs_service: fix a potential dead lock issue

### DIFF
--- a/src/ipvs/ip_vs_service.c
+++ b/src/ipvs/ip_vs_service.c
@@ -661,6 +661,7 @@ static void __dp_vs_del_service(struct dp_vs_service *svc)
         if (svc->match)
             rte_free(svc->match);
         rte_free(svc);
+        svc = NULL;
     }
 }
 
@@ -998,8 +999,6 @@ static int dp_vs_set_svc(sockoptid_t opt, const void *user, size_t len)
             break;
         case DPVS_SO_SET_DEL:
             ret = dp_vs_del_service(svc);
-            // reset svc to avoid use after free
-            svc = NULL;
             break;
         case DPVS_SO_SET_ZERO:
             ret = dp_vs_zero_service(svc);


### PR DESCRIPTION
It would be better to move svc = NULL right after rte_free(svc).