### PR TITLE
ipvs: correct the byte order of some members of fnat_seq and syn_prox…

### DIFF
--- a/src/ipvs/ip_vs_conn.c
+++ b/src/ipvs/ip_vs_conn.c
@@ -821,7 +821,7 @@ struct dp_vs_conn *dp_vs_conn_new(struct rte_mbuf *mbuf,
             htonl((uint32_t) ((ntohl(th->ack_seq) - 1)));
 
         /* save ack_seq */
-        new->fnat_seq.fdata_seq = htonl(th->ack_seq);
+        new->fnat_seq.fdata_seq = ntohl(th->ack_seq);
 
         /* FIXME: use DP_VS_TCP_S_SYN_SENT for syn */
         pp = dp_vs_proto_lookup(param->proto);

--- a/src/ipvs/ip_vs_synproxy.c
+++ b/src/ipvs/ip_vs_synproxy.c
@@ -689,7 +689,7 @@ int dp_vs_synproxy_syn_rcv(int af, struct rte_mbuf *mbuf,
         goto syn_rcv_out;
 
     if (th->syn && !th->ack && !th->rst && !th->fin &&
-            (svc = dp_vs_service_lookup(af, iph->proto, 
+            (svc = dp_vs_service_lookup(af, iph->proto,
                                         &iph->daddr, th->dest, 0, NULL, NULL, NULL)) &&
             (svc->flags & DP_VS_SVC_F_SYNPROXY)) {
         /* if service's weight is zero (non-active realserver),
@@ -1227,7 +1227,7 @@ int dp_vs_synproxy_synack_rcv(struct rte_mbuf *mbuf, struct dp_vs_conn *cp,
     if ((th->syn) && (th->ack) && (!th->rst) &&
             (cp->flags & DPVS_CONN_F_SYNPROXY) &&
             (cp->state == DPVS_TCP_S_SYN_SENT)) {
-        cp->syn_proxy_seq.delta = htonl(cp->syn_proxy_seq.isn) - htonl(th->seq);
+        cp->syn_proxy_seq.delta = ntohl(cp->syn_proxy_seq.isn) - ntohl(th->seq);
         cp->state = DPVS_TCP_S_ESTABLISHED;
         conn_timeout = dp_vs_get_conn_timeout(cp);
         if (unlikely((conn_timeout != 0) && (cp->proto == IPPROTO_TCP)))
@@ -1308,8 +1308,7 @@ int dp_vs_synproxy_synack_rcv(struct rte_mbuf *mbuf, struct dp_vs_conn *cp,
                 __func__, ntohl(th->seq), ntohl(th->ack_seq));
 
         /* Count the delta of seq */
-        cp->syn_proxy_seq.delta =
-            ntohl(cp->syn_proxy_seq.isn) - ntohl(th->seq);
+        cp->syn_proxy_seq.delta = ntohl(cp->syn_proxy_seq.isn) - ntohl(th->seq);
         cp->state = DPVS_TCP_S_CLOSE;
         cp->timeout.tv_sec = pp->timeout_table[cp->state];
         dpvs_time_rand_delay(&cp->timeout, 1000000);


### PR DESCRIPTION
…y_seq.

- "fnat_seq's isn" uses host-byte order while "syn_proxy_seq's isn" uses
  network-byte order.

- Both "delta" and "fdata_seq" use host-byte order within fnat_seq and
  syn_proxy_seq.

o struct dp_vs_seq fnat_seq;
struct dp_vs_seq {
    uint32_t  isn;          // host-byte order
    uint32_t  delta;        // host-byte order
    uint32_t  fdata_seq;    // host-byte order
    uint32_t  prev_delta;    // unused
};

o struct dp_vs_seq syn_proxy_seq;
struct dp_vs_seq {
    uint32_t  isn;          // network-byte order
    uint32_t  delta;        // host-byte order
    uint32_t  fdata_seq;    // host-byte order
    uint32_t  prev_delta;    // unused
};