### PR TITLE
ctrl: increase buffer size to 8192 from 4096.

### DIFF
--- a/src/ctrl.c
+++ b/src/ctrl.c
@@ -991,7 +991,7 @@ static inline int msg_init(void)
     int ii, jj;
     int ret;
     char ring_name[16];
-    char buf[4096];
+    char buf[8192];
 
     if (DPVS_MAX_LCORE > MSG_MAX_LCORE_SUPPORTED)
         return EDPVS_NOTSUPP;


### PR DESCRIPTION
o When dpvs runs with 16 worker cores, like 'dpvs -- -l 0,1-8,11-18', we need to
  larger buffer to accommodate the debugging info.