### PR TITLE
fdir: add "filter" switch of fdir config to support multi-core processing in VM

### DIFF
--- a/conf/dpvs.conf.items
+++ b/conf/dpvs.conf.items
@@ -34,6 +34,7 @@ netif_defs {
             descriptor_number   512         <512, 16-8192>
         }
         fdir {
+            <init> filter       on          <on, on/off>
             mode                perfect     <perfect, none|signature|perfect|perfect_mac_vlan|perfect_tunnel>
             pballoc             64k         <64k, 64k|128k|256k>
             status              matched     <matched, close|matched|always>

--- a/include/netif.h
+++ b/include/netif.h
@@ -333,4 +333,6 @@ static inline uint16_t dpvs_rte_eth_dev_count(void)
 #endif
 }
 
+extern bool dp_vs_fdir_filter_enable;
+
 #endif /* __DPVS_NETIF_H__ */

--- a/src/netif.c
+++ b/src/netif.c
@@ -149,6 +149,8 @@ static uint8_t g_isol_rx_lcore_num;
 static uint64_t g_slave_lcore_mask;
 static uint64_t g_isol_rx_lcore_mask;
 
+bool dp_vs_fdir_filter_enable = true;
+
 bool is_lcore_id_valid(lcoreid_t cid)
 {
     if (unlikely(cid >= DPVS_MAX_LCORE))
@@ -470,6 +472,24 @@ static void fdir_status_handler(vector_t tokens)
     else
         RTE_LOG(INFO, NETIF, "%s:fdir_status = %s\n",
                 current_device->name, status);
+
+    FREE_PTR(str);
+}
+
+static void fdir_filter_handler(vector_t tokens)
+{
+    char *str = set_value(tokens);
+
+    assert(str);
+
+    if (strcasecmp(str, "on") == 0)
+        dp_vs_fdir_filter_enable = true;
+    else if (strcasecmp(str, "off") == 0)
+        dp_vs_fdir_filter_enable = false;
+    else
+        RTE_LOG(WARNING, IPVS, "invalid fdir:filter %s\n", str);
+
+    RTE_LOG(INFO, IPVS, "fdir:filter = %s\n", dp_vs_fdir_filter_enable ? "on" : "off");
 
     FREE_PTR(str);
 }
@@ -839,6 +859,7 @@ void install_netif_keywords(void)
     install_keyword("mode", fdir_mode_handler, KW_TYPE_INIT);
     install_keyword("pballoc", fdir_pballoc_handler, KW_TYPE_INIT);
     install_keyword("status", fdir_status_handler, KW_TYPE_INIT);
+    install_keyword("filter", fdir_filter_handler, KW_TYPE_INIT);
     install_sublevel_end();
     install_keyword("promisc_mode", promisc_mode_handler, KW_TYPE_INIT);
     install_keyword("kni_name", kni_name_handler, KW_TYPE_INIT);


### PR DESCRIPTION
o By default, fdir filter is always enabled.
```
netif_defs {
    ...
    <init> device dpdk0 {
        fdir {
            ...
            <init> filter  on
        }
    }
    ...
}
```

o In some case that dpvs is deployed in some VM, VM does not support fdir filter
  configuration so only ONE single worker core can be used accordingly. In fact,
  we don't need to add fdir filters, but create only the specific sa pools.

  With "packet redirect" enabled, multiple worker cores can be used accordingly
  for the benefit of performance, like cps/pps.

```
netif_defs {
    ...
    <init> device dpdk0 {
        fdir {
            filter  off
        }
    }
    ...
}

ipvs_defs {
      conn {
          redirect  on
      }
  }
```