### PR TITLE
ipvs: remove unnecessary check for tunnel termination

### DIFF
--- a/src/ip_gre.c
+++ b/src/ip_gre.c
@@ -327,9 +327,5 @@ int gre_term(void)
     if (err != EDPVS_OK)
         return err;
 
-    err = ip_tunnel_term_tab(&gre_tunnel_tab);
-    if (err != EDPVS_OK)
-        return err;
-
-    return err;
+    return ip_tunnel_term_tab(&gre_tunnel_tab);
 }

--- a/src/ipip.c
+++ b/src/ipip.c
@@ -133,9 +133,5 @@ int ipip_term(void)
         return err;
     }
 
-    err = ip_tunnel_term_tab(&ipip_tunnel_tab);
-    if (err != EDPVS_OK)
-        RTE_LOG(ERR, IPIP, "%s: fail to term tab\n", __func__);
-
-    return err;
+    return ip_tunnel_term_tab(&ipip_tunnel_tab);
 }


### PR DESCRIPTION
Since ip_tunnel_term_tab always return EDPVS_OK, it's unecessary to
check the return code.

Signed-off-by: Haishuang Yan <yanhaishuang@cmss.chinamobile.com>