### PR TITLE
make it possible to bind laddr to lcore by adding laddr_lcore_mapping

### DIFF
--- a/conf/dpvs.bond.conf.sample
+++ b/conf/dpvs.bond.conf.sample
@@ -371,4 +371,5 @@ ipvs_defs {
 ! sa_pool config
 sa_pool {
     pool_hash_size   16
+    pool_mode        laddr_lcore_mapping
 }

--- a/conf/dpvs.conf.items
+++ b/conf/dpvs.conf.items
@@ -245,4 +245,5 @@ ipvs_defs {
 
 sa_pool {
     <init> pool_hash_size   16  <16, 1-128>
+    <init> pool_mode        laddr_lcore_mapping
 }

--- a/conf/dpvs.conf.sample
+++ b/conf/dpvs.conf.sample
@@ -324,4 +324,5 @@ ipvs_defs {
 ! sa_pool config
 sa_pool {
     pool_hash_size   16
+    pool_mode        laddr_lcore_mapping
 }

--- a/conf/dpvs.conf.single-bond.sample
+++ b/conf/dpvs.conf.single-bond.sample
@@ -276,4 +276,5 @@ ipvs_defs {
 ! sa_pool config
 sa_pool {
     pool_hash_size   16
+    pool_mode        laddr_lcore_mapping
 }

--- a/conf/dpvs.conf.single-nic.sample
+++ b/conf/dpvs.conf.single-nic.sample
@@ -249,4 +249,5 @@ ipvs_defs {
 ! sa_pool config
 sa_pool {
     pool_hash_size   16
+    pool_mode        laddr_lcore_mapping
 }

--- a/include/ipvs/service.h
+++ b/include/ipvs/service.h
@@ -44,6 +44,12 @@
 
 rte_rwlock_t __dp_vs_svc_lock;
 
+struct laddr_list_pre_lcore {
+    struct list_head    laddr_list; /* local address (LIP) pool */
+    struct list_head    *laddr_curr;
+    uint32_t            num_laddrs;
+};
+
 /* virtual service */
 struct dp_vs_service {
     struct list_head    s_list;     /* node for normal service table */
@@ -87,6 +93,9 @@ struct dp_vs_service {
     struct list_head    *laddr_curr;
     rte_rwlock_t        laddr_lock;
     uint32_t            num_laddrs;
+
+    struct laddr_list_pre_lcore pre_list[RTE_MAX_LCORE];
+#define this_pre_list pre_list[rte_lcore_id()]
 
     /* ... flags, timer ... */
 } __rte_cache_aligned;

--- a/include/sa_pool.h
+++ b/include/sa_pool.h
@@ -42,11 +42,22 @@
 #ifndef __DPVS_SA_POOL__
 #define __DPVS_SA_POOL__
 
+#define SAPOOL
+#define RTE_LOGTYPE_SAPOOL  RTE_LOGTYPE_USER1
+
+enum {
+    LADDR_LCORE_MAPPING_POOL_MODE,
+    LPORT_LCORE_MAPPING_POOL_MODE,
+};
+
 struct sa_pool_stats {
     uint32_t used_cnt;
     uint32_t free_cnt;
     uint32_t miss_cnt;
 };
+
+extern uint8_t sa_pool_mode;
+#define SA_POOL_MODE sa_pool_mode
 
 int sa_pool_init(void);
 int sa_pool_term(void);

--- a/src/ipvs/ip_vs_service.c
+++ b/src/ipvs/ip_vs_service.c
@@ -471,6 +471,7 @@ int dp_vs_add_service(struct dp_vs_service_conf *u,
 {
     int ret = 0;
     int size;
+    int cid = 0;
     struct dp_vs_scheduler *sched = NULL;
     struct dp_vs_service *svc = NULL;
 
@@ -522,6 +523,11 @@ int dp_vs_add_service(struct dp_vs_service_conf *u,
     svc->num_laddrs = 0;
     svc->laddr_curr = &svc->laddr_list;
 
+    for (cid = 0; cid < RTE_MAX_LCORE; cid++) {
+        INIT_LIST_HEAD(&svc->pre_list[cid].laddr_list);
+        svc->pre_list[cid].laddr_curr = &svc->pre_list[cid].laddr_list;
+        svc->pre_list[cid].num_laddrs = 0;
+    }
     INIT_LIST_HEAD(&svc->dests);
     rte_rwlock_init(&svc->sched_lock);
 

--- a/src/sa_pool.c
+++ b/src/sa_pool.c
@@ -60,14 +60,14 @@
 #define DEF_MIN_PORT        1025
 #define DEF_MAX_PORT        65535
 
-#define SAPOOL
-#define RTE_LOGTYPE_SAPOOL  RTE_LOGTYPE_USER1
-
 #define MAX_FDIR_PROTO      2
 
 #define SAPOOL_DEF_HASH_SZ  16
 #define SAPOOL_MIN_HASH_SZ  1
 #define SAPOOL_MAX_HASH_SZ  128
+
+#define LPORT_LCORE_MAPPING_POOL_MODE_NAME "lport_lcore_mapping"
+#define LADDR_LCORE_MAPPING_POOL_MODE_NAME "laddr_lcore_mapping"
 
 enum {
     SA_F_USED               = 0x01,
@@ -99,8 +99,8 @@ struct sa_entry_pool {
     /* another way is use total_used/free_cnt in sa_pool,
      * so that we need not travels the hash to get stats.
      * we use cnt here, since we may need per-pool stats. */
-    rte_atomic16_t          used_cnt;
-    rte_atomic16_t          free_cnt;
+    rte_atomic32_t          used_cnt;
+    rte_atomic32_t          free_cnt;
     uint32_t                miss_cnt;
 };
 
@@ -139,8 +139,74 @@ static uint8_t              sa_nlcore;
 static uint64_t             sa_lcore_mask;
 
 static uint8_t              sa_pool_hash_size   = SAPOOL_DEF_HASH_SZ;
+uint8_t                     sa_pool_mode = LPORT_LCORE_MAPPING_POOL_MODE;
+extern uint32_t             lcore_ids[RTE_MAX_LCORE];
 
-static int __add_del_filter(int af, struct netif_port *dev, lcoreid_t cid,
+static int __add_del_filter_addr_mode(int af, struct netif_port *dev, lcoreid_t cid,
+                            const union inet_addr *dip,
+                            uint32_t filter_id[MAX_FDIR_PROTO], bool add)
+{
+    struct rte_eth_fdir_filter filt = {
+            .action.behavior = RTE_ETH_FDIR_ACCEPT,
+            .action.report_status = RTE_ETH_FDIR_REPORT_ID,
+            .soft_id = filter_id[0],
+    };
+
+    if (af == AF_INET) {
+        filt.input.flow_type = RTE_ETH_FLOW_NONFRAG_IPV4_OTHER;
+        filt.input.flow.ip4_flow.dst_ip = dip->in.s_addr;
+    } else if (af == AF_INET6) {
+        filt.input.flow_type = RTE_ETH_FLOW_NONFRAG_IPV6_OTHER;
+        memcpy(filt.input.flow.ipv6_flow.dst_ip, &dip->in6, sizeof(struct in6_addr));
+    } else {
+        return EDPVS_NOTSUPP;
+    }
+
+    queueid_t queue;
+    int err;
+    enum rte_filter_op op;
+#ifdef CONFIG_DPVS_SAPOOL_DEBUG
+    char ipaddr[64];
+#endif
+
+    if (dev->netif_ops && dev->netif_ops->op_filter_supported) {
+        if (dev->netif_ops->op_filter_supported(dev, RTE_ETH_FILTER_FDIR) < 0) {
+            if (dev->nrxq <= 1)
+                return EDPVS_OK;
+            RTE_LOG(ERR, SAPOOL, "%s: FDIR is not supported by device %s. Only"
+                    " single rxq can be configured.\n", __func__, dev->name);
+            return EDPVS_NOTSUPP;
+        }
+    } else {
+        RTE_LOG(ERR, SAPOOL, "%s: FDIR support of device %s is not known.\n",
+                __func__, dev->name);
+        return EDPVS_INVAL;
+    }
+
+    err = netif_get_queue(dev, cid, &queue);
+    if (err != EDPVS_OK)
+        return err;
+
+    filt.action.rx_queue = queue;
+    op = add ? RTE_ETH_FILTER_ADD : RTE_ETH_FILTER_DELETE;
+
+    err = netif_fdir_filter_set(dev, op, &filt);
+    if (err != EDPVS_OK)
+        return err;
+
+#ifdef CONFIG_DPVS_SAPOOL_DEBUG
+    RTE_LOG(DEBUG, SAPOOL, "FDIR: %s %s %s TCP/UDP "
+            "ip %s queue %d lcore %2d filterID %d\n",
+            add ? "add" : "del", dev->name,
+            af == AF_INET ? "IPv4" : "IPv6",
+            inet_ntop(af, dip, ipaddr, sizeof(ipaddr)) ? : "::",
+            queue, cid, filter_id[0]);
+#endif
+
+    return err;
+}
+
+static int __add_del_filter_port_mode(int af, struct netif_port *dev, lcoreid_t cid,
                             const union inet_addr *dip, __be16 dport,
                             uint32_t filter_id[MAX_FDIR_PROTO], bool add)
 {
@@ -230,6 +296,16 @@ static int __add_del_filter(int af, struct netif_port *dev, lcoreid_t cid,
     return err;
 }
 
+static int __add_del_filter(int af, struct netif_port *dev, lcoreid_t cid,
+                            const union inet_addr *dip, __be16 dport,
+                            uint32_t filter_id[MAX_FDIR_PROTO], bool add)
+{
+    if (SA_POOL_MODE == LPORT_LCORE_MAPPING_POOL_MODE)
+        return __add_del_filter_port_mode(af, dev, cid, dip, dport, filter_id, add);
+    else
+        return __add_del_filter_addr_mode(af, dev, cid, dip, filter_id, add);
+}
+
 static inline int sa_add_filter(int af, struct netif_port *dev, lcoreid_t cid,
                                 const union inet_addr *dip, __be16 dport,
                                 uint32_t filter_id[MAX_FDIR_PROTO])
@@ -264,13 +340,13 @@ static int sa_pool_alloc_hash(struct sa_pool *ap, uint8_t hash_sz,
         INIT_LIST_HEAD(&pool->used_enties);
         INIT_LIST_HEAD(&pool->free_enties);
 
-        rte_atomic16_set(&pool->used_cnt, 0);
-        rte_atomic16_set(&pool->free_cnt, 0);
+        rte_atomic32_set(&pool->used_cnt, 0);
+        rte_atomic32_set(&pool->free_cnt, 0);
 
         for (port = ap->low; port <= ap->high; port++) {
             struct sa_entry *sa;
-
-            if (fdir->mask &&
+            if (SA_POOL_MODE == LPORT_LCORE_MAPPING_POOL_MODE &&
+                fdir->mask &&
                 ((uint16_t)port & fdir->mask) != ntohs(fdir->port_base))
                 continue;
 
@@ -278,7 +354,7 @@ static int sa_pool_alloc_hash(struct sa_pool *ap, uint8_t hash_sz,
             sa->addr = ap->ifa->addr;
             sa->port = htons((uint16_t)port);
             list_add_tail(&sa->list, &pool->free_enties);
-            rte_atomic16_inc(&pool->free_cnt);
+            rte_atomic32_inc(&pool->free_cnt);
         }
     }
 
@@ -292,12 +368,54 @@ static int sa_pool_free_hash(struct sa_pool *ap)
     return EDPVS_OK;
 }
 
-int sa_pool_create(struct inet_ifaddr *ifa, uint16_t low, uint16_t high)
+static int __sa_pool_create(struct inet_ifaddr *ifa, lcoreid_t cid,
+                            uint16_t low, uint16_t high)
 {
+    uint32_t filtids[MAX_FDIR_PROTO];
+    struct sa_fdir *fdir = &sa_fdirs[cid];
     struct sa_pool *ap;
     int err;
-    lcoreid_t cid;
+    ap = rte_zmalloc(NULL, sizeof(struct sa_pool), 0);
+    if (!ap) {
+        err = EDPVS_NOMEM;
+        goto errout;
+    }
 
+    ap->ifa = ifa;
+    ap->low = low;
+    ap->high = high;
+    rte_atomic32_set(&ap->refcnt, 0);
+
+    err = sa_pool_alloc_hash(ap, sa_pool_hash_size, fdir);
+    if (err != EDPVS_OK) {
+        rte_free(ap);
+        goto errout;
+    }
+
+    /* if add filter failed, waste some soft-id is acceptable. */
+    filtids[0] = fdir->soft_id++;
+    filtids[1] = fdir->soft_id++;
+        err = sa_add_filter(ifa->af, ifa->idev->dev, cid, &ifa->addr,
+                        fdir->port_base, filtids);
+    if (err != EDPVS_OK) {
+        sa_pool_free_hash(ap);
+        rte_free(ap);
+        goto errout;
+    }
+    ap->filter_id[0] = filtids[0];
+    ap->filter_id[1] = filtids[1];
+
+    ifa->sa_pools[cid] = ap;
+    return EDPVS_OK;
+errout:
+    return err;
+}
+
+int sa_pool_create(struct inet_ifaddr *ifa, uint16_t low, uint16_t high)
+{
+    int err;
+    lcoreid_t cid;
+    static unsigned idx = 0;
     low = low ? : DEF_MIN_PORT;
     high = high ? : DEF_MAX_PORT;
 
@@ -306,47 +424,25 @@ int sa_pool_create(struct inet_ifaddr *ifa, uint16_t low, uint16_t high)
         return EDPVS_INVAL;
     }
 
-    for (cid = 0; cid < RTE_MAX_LCORE; cid++) {
-        uint32_t filtids[MAX_FDIR_PROTO];
-        struct sa_fdir *fdir = &sa_fdirs[cid];
+    if (SA_POOL_MODE == LADDR_LCORE_MAPPING_POOL_MODE) {
+        cid = lcore_ids[(idx++) % sa_nlcore];
+        err = __sa_pool_create(ifa, cid, low, high);
 
-        /* skip master and unused cores */
-        if (cid > 64 || !(sa_lcore_mask & (1L << cid)))
-            continue;
-        assert(rte_lcore_is_enabled(cid) && cid != rte_get_master_lcore());
-
-        ap = rte_zmalloc(NULL, sizeof(struct sa_pool), 0);
-        if (!ap) {
-            err = EDPVS_NOMEM;
+        if (idx >= sa_nlcore)
+            idx = 0;
+        if (err != EDPVS_OK)
             goto errout;
+    } else if (SA_POOL_MODE == LPORT_LCORE_MAPPING_POOL_MODE) {
+        for (cid = 0; cid < RTE_MAX_LCORE; cid++) {
+            /* skip master and unused cores */
+            if (cid > 64 || !(sa_lcore_mask & (1L << cid)))
+                continue;
+            assert(rte_lcore_is_enabled(cid) && cid != rte_get_master_lcore());
+            err = __sa_pool_create(ifa, cid, low, high);
+
+            if (err != EDPVS_OK)
+                goto errout;
         }
-
-        ap->ifa = ifa;
-        ap->low = low;
-        ap->high = high;
-        rte_atomic32_set(&ap->refcnt, 0);
-
-        err = sa_pool_alloc_hash(ap, sa_pool_hash_size, fdir);
-        if (err != EDPVS_OK) {
-            rte_free(ap);
-            goto errout;
-        }
-
-        /* if add filter failed, waste some soft-id is acceptable. */
-        filtids[0] = fdir->soft_id++;
-        filtids[1] = fdir->soft_id++;
-
-        err = sa_add_filter(ifa->af, ifa->idev->dev, cid, &ifa->addr,
-                            fdir->port_base, filtids);
-        if (err != EDPVS_OK) {
-            sa_pool_free_hash(ap);
-            rte_free(ap);
-            goto errout;
-        }
-        ap->filter_id[0] = filtids[0];
-        ap->filter_id[1] = filtids[1];
-
-        ifa->sa_pools[cid] = ap;
     }
 
 #ifdef CONFIG_DPVS_SAPOOL_DEBUG
@@ -443,8 +539,8 @@ static inline int sa_pool_fetch(struct sa_entry_pool *pool,
     if (!ent) {
 #ifdef CONFIG_DPVS_SAPOOL_DEBUG
         RTE_LOG(DEBUG, SAPOOL, "%s: no entry (used/free %d/%d)\n", __func__,
-                rte_atomic16_read(&pool->used_cnt),
-                rte_atomic16_read(&pool->free_cnt));
+                rte_atomic32_read(&pool->used_cnt),
+                rte_atomic32_read(&pool->free_cnt));
 #endif
         pool->miss_cnt++;
         return EDPVS_RESOURCE;
@@ -464,8 +560,8 @@ static inline int sa_pool_fetch(struct sa_entry_pool *pool,
 
     ent->flags |= SA_F_USED;
     list_move_tail(&ent->list, &pool->used_enties);
-    rte_atomic16_inc(&pool->used_cnt);
-    rte_atomic16_dec(&pool->free_cnt);
+    rte_atomic32_inc(&pool->used_cnt);
+    rte_atomic32_dec(&pool->free_cnt);
 
 #ifdef CONFIG_DPVS_SAPOOL_DEBUG
     RTE_LOG(DEBUG, SAPOOL, "%s: %s:%d fetched!\n", __func__,
@@ -515,8 +611,8 @@ static inline int sa_pool_release(struct sa_entry_pool *pool,
 
     ent->flags &= (~SA_F_USED);
     list_move_tail(&ent->list, &pool->free_enties);
-    rte_atomic16_dec(&pool->used_cnt);
-    rte_atomic16_inc(&pool->free_cnt);
+    rte_atomic32_dec(&pool->used_cnt);
+    rte_atomic32_inc(&pool->free_cnt);
 
 #ifdef CONFIG_DPVS_SAPOOL_DEBUG
     RTE_LOG(DEBUG, SAPOOL, "%s: %s:%d released!\n", __func__,
@@ -830,8 +926,8 @@ static int sa_msg_get_stats(struct dpvs_msg *msg)
         pool = &ifa->this_sa_pool->pool_hash[hash];
         assert(pool);
 
-        stats->used_cnt += rte_atomic16_read(&pool->used_cnt);
-        stats->free_cnt += rte_atomic16_read(&pool->free_cnt);
+        stats->used_cnt += rte_atomic32_read(&pool->used_cnt);
+        stats->free_cnt += rte_atomic32_read(&pool->free_cnt);
         stats->miss_cnt += pool->miss_cnt;
     }
 
@@ -894,6 +990,22 @@ int sa_pool_term(void)
 /*
  * config file
  */
+static void pool_mode_handler(vector_t tokens)
+{
+    char *str = set_value(tokens);
+    assert(str);
+
+    if (!strcmp(str, LADDR_LCORE_MAPPING_POOL_MODE_NAME))
+        sa_pool_mode = LADDR_LCORE_MAPPING_POOL_MODE;
+    else if (!strcmp(str, LPORT_LCORE_MAPPING_POOL_MODE_NAME))
+        sa_pool_mode = LPORT_LCORE_MAPPING_POOL_MODE;
+    else
+        RTE_LOG(WARNING, SAPOOL, "invalid pool_mode %s, use default %s\n",
+                    str, LPORT_LCORE_MAPPING_POOL_MODE_NAME);
+
+    FREE_PTR(str);
+}
+
 static void sa_pool_hash_size_conf(vector_t tokens)
 {
     char *str = set_value(tokens);
@@ -915,5 +1027,6 @@ static void sa_pool_hash_size_conf(vector_t tokens)
 void install_sa_pool_keywords(void)
 {
     install_keyword_root("sa_pool", NULL);
+    install_keyword("pool_mode", pool_mode_handler, KW_TYPE_INIT);
     install_keyword("pool_hash_size", sa_pool_hash_size_conf, KW_TYPE_INIT);
 }


### PR DESCRIPTION
option. In this mode, dest addr is needed in FDIR instead of dest addr and dest port mask.

NOTICE:
number of laddrs should be greater or equal to number of slave lcores.
Or, some slave lcores will have no laddr causing FNAT fowarding failed in
those slave lcores.

Co-authored-by: kldeng <kldeng05@gmail.com>
Co-authored-by: lixiaoxiao <lixiaoxiao@360.cn>