### PR TITLE
ipvs: rename dp_vs_add_stats() to dp_vs_stats_add().

### DIFF
--- a/include/ipvs/stats.h
+++ b/include/ipvs/stats.h
@@ -85,7 +85,7 @@ int dp_vs_stats_init(void);
 int dp_vs_stats_term(void);
 
 void dp_vs_stats_clear(struct dp_vs_stats *stats);
-
+int dp_vs_stats_add(struct dp_vs_stats *dst, struct dp_vs_stats *src);
 int dp_vs_stats_in(struct dp_vs_conn *conn, struct rte_mbuf *mbuf);
 int dp_vs_stats_out(struct dp_vs_conn *conn, struct rte_mbuf *mbuf);
 void dp_vs_stats_conn(struct dp_vs_conn *conn);
@@ -93,8 +93,5 @@ void dp_vs_stats_conn(struct dp_vs_conn *conn);
 void dp_vs_estats_inc(enum dp_vs_estats_type field);
 void dp_vs_estats_clear(void);
 uint64_t dp_vs_estats_get(enum dp_vs_estats_type field);
-int dp_vs_add_stats(struct dp_vs_stats* dst, struct dp_vs_stats* src);
-
-int dp_vs_copy_stats(struct dp_vs_stats* dst, struct dp_vs_stats* src);
 
 #endif /* __DPVS_STATS_H__ */

--- a/src/ipvs/ip_vs_dest.c
+++ b/src/ipvs/ip_vs_dest.c
@@ -299,7 +299,7 @@ int dp_vs_get_dest_entries(const struct dp_vs_service *svc,
         entry.actconns = rte_atomic32_read(&dest->actconns);
         entry.inactconns = rte_atomic32_read(&dest->inactconns);
         entry.persistconns = rte_atomic32_read(&dest->persistconns);
-        ret = dp_vs_add_stats(&(entry.stats), &dest->stats);
+        ret = dp_vs_stats_add(&(entry.stats), &dest->stats);
         if (ret != EDPVS_OK)
             break;
 

--- a/src/ipvs/ip_vs_stats.c
+++ b/src/ipvs/ip_vs_stats.c
@@ -40,7 +40,7 @@ void dp_vs_stats_clear(struct dp_vs_stats *stats)
     stats->outbytes = 0;
 }
 
-int dp_vs_add_stats(struct dp_vs_stats* dst, struct dp_vs_stats* src)
+int dp_vs_stats_add(struct dp_vs_stats *dst, struct dp_vs_stats *src)
 {
     dst->conns    += src->conns;
     dst->inpkts   += src->inpkts;


### PR DESCRIPTION
- Keep conformity of the same function name style, module_name_verb() like
  dp_vs_conn_get().
- Remove dp_vs_copy_stats() that has no definition.