### PR TITLE
netif: allow to use the non-continuous lcores, like "-l 0,1-8,11-18".

### DIFF
--- a/src/netif.c
+++ b/src/netif.c
@@ -1263,36 +1263,32 @@ static void netif_get_isol_rx_lcores(uint8_t *nb, uint64_t *mask)
         *mask = isol_lcore_mask;
 }
 
-static void build_lcore_index(int lcore_max)
+static void build_lcore_index(void)
 {
-    int idx = 0, ii;
+    int i, idx = 0;
 
     g_lcore_index[idx++] = rte_get_master_lcore();
 
-    for (ii = 0; ii < lcore_max; ii++)
-        if (g_lcore_role[ii] == LCORE_ROLE_FWD_WORKER)
-            g_lcore_index[idx++] = ii;
+    for (i = 0; i < DPVS_MAX_LCORE; i++)
+        if (g_lcore_role[i] == LCORE_ROLE_FWD_WORKER)
+            g_lcore_index[idx++] = i;
 
-    for (ii = 0; ii < lcore_max; ii++)
-        if (g_lcore_role[ii] == LCORE_ROLE_ISOLRX_WORKER)
-            g_lcore_index[idx++] = ii;
+    for (i = 0; i < DPVS_MAX_LCORE; i++)
+        if (g_lcore_role[i] == LCORE_ROLE_ISOLRX_WORKER)
+            g_lcore_index[idx++] = i;
 }
 
 static void lcore_role_init(void)
 {
-    int i, cid, lcore_max_count;
+    int i, cid;
 
-    lcore_max_count = rte_lcore_count();
-    if (lcore_max_count > DPVS_MAX_LCORE)
-        lcore_max_count = DPVS_MAX_LCORE;
-    else
-        for (cid = lcore_max_count; cid < DPVS_MAX_LCORE; cid++)
-            g_lcore_role[cid] = LCORE_ROLE_MAX;  // invalidate nonexistent lcores
-    for (cid = 0; cid < lcore_max_count; cid++)
+    for (cid = 0; cid < DPVS_MAX_LCORE; cid++)
         if (!rte_lcore_is_enabled(cid))
-            g_lcore_role[cid] = LCORE_ROLE_MAX;  // invalidate disabled lcores
+            /* invalidate the disabled cores */
+            g_lcore_role[cid] = LCORE_ROLE_MAX;
 
     cid = rte_get_master_lcore();
+
     assert(g_lcore_role[cid] == LCORE_ROLE_IDLE);
     g_lcore_role[cid] = LCORE_ROLE_MASTER;
 
@@ -1304,17 +1300,18 @@ static void lcore_role_init(void)
         i++;
     }
 
-    for (cid = 0; cid < lcore_max_count; cid++) {
+    for (cid = 0; cid < DPVS_MAX_LCORE; cid++) {
         if (!list_empty(&isol_rxq_tab[cid])) {
             assert(g_lcore_role[cid] == LCORE_ROLE_IDLE);
             g_lcore_role[cid] =  LCORE_ROLE_ISOLRX_WORKER;
         }
     }
 
-    build_lcore_index(lcore_max_count);
+    build_lcore_index();
 
     for (cid = 0; cid < DPVS_MAX_LCORE; cid++)
-        printf("[%02d]\t\t\t%s\n", cid, dpvs_lcore_role_str(g_lcore_role[cid]));
+        RTE_LOG(INFO, NETIF, "[%02d]: %s\n",
+                cid, dpvs_lcore_role_str(g_lcore_role[cid]));
 }
 
 static inline void netif_copy_lcore_stats(struct netif_lcore_stats *stats)

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -32,21 +32,18 @@ struct dpvs_role_str {
 
 const char *dpvs_lcore_role_str(dpvs_lcore_role_t role)
 {
-    int i;
-    const static struct dpvs_role_str role_str_tab[] = {
-        { LCORE_ROLE_IDLE,          "lcore_role_idle"  },
-        { LCORE_ROLE_MASTER,        "lcore_role_master" },
-        { LCORE_ROLE_FWD_WORKER,    "lcore_role_fwd_worker"},
-        { LCORE_ROLE_ISOLRX_WORKER, "lcore_role_isolrx_worker"},
-        { LCORE_ROLE_MAX,           "lcore_role_null"},
+    static const char *role_str_tab[] = {
+        [LCORE_ROLE_IDLE]          = "lcre_role_idle",
+        [LCORE_ROLE_MASTER]        = "lcre_role_master",
+        [LCORE_ROLE_FWD_WORKER]    = "lcre_role_fwd_worker",
+        [LCORE_ROLE_ISOLRX_WORKER] = "lcre_role_isolrx_worker",
+        [LCORE_ROLE_MAX]           = "lcre_role_null"
     };
 
-    for (i = 0; i < NELEMS(role_str_tab); i++) {
-        if (role == role_str_tab[i].role)
-            return role_str_tab[i].str;
-    }
-
-    return "lcore_role_unkown";
+    if (likely(role >= LCORE_ROLE_IDLE && role <= LCORE_ROLE_MAX))
+        return role_str_tab[role];
+    else
+        return "lcore_role_unknown";
 }
 
 int dpvs_scheduler_init(void)


### PR DESCRIPTION
- Currently, the crash is met caused by the below assertion when dpvs runs
  with "-- -l 0,1-8,11-18".

  assert(g_lcore_role[cid] == LCORE_ROLE_IDLE) within lcore_role_init().

  Without the fix, g_lcore_role[17] is LCORE_ROLE_MAX so dpvs crashes.