### PR TITLE
Fix compile error caused by inline method.

### DIFF
--- a/include/ipvs/conn.h
+++ b/include/ipvs/conn.h
@@ -298,7 +298,7 @@ dp_vs_conn_clear_redirect_hashed(struct dp_vs_conn *conn)
     conn->flags &= ~DPVS_CONN_F_REDIRECT_HASHED;
 }
 
-inline uint32_t dp_vs_conn_hashkey(int af,
+uint32_t dp_vs_conn_hashkey(int af,
     const union inet_addr *saddr, uint16_t sport,
     const union inet_addr *daddr, uint16_t dport,
     uint32_t mask);

--- a/include/timer.h
+++ b/include/timer.h
@@ -54,8 +54,8 @@ struct dpvs_timer {
     dpvs_tick_t         delay;
 };
 
-inline dpvs_tick_t timeval_to_ticks(const struct timeval *tv);
-inline void ticks_to_timeval(const dpvs_tick_t ticks, struct timeval *tv);
+dpvs_tick_t timeval_to_ticks(const struct timeval *tv);
+void ticks_to_timeval(const dpvs_tick_t ticks, struct timeval *tv);
 
 int dpvs_timer_init(void);
 int dpvs_timer_term(void);


### PR DESCRIPTION
Without this patch,

```
/tmp/dpvs/src//../include/timer.h:54:13: error: inline function ‘ticks_to_timeval’ declared but never defined [-Werror]
 inline void ticks_to_timeval(const dpvs_tick_t ticks, struct timeval *tv);
             ^~~~~~~~~~~~~~~~
/tmp/dpvs/src//../include/timer.h:53:20: error: inline function ‘timeval_to_ticks’ declared but never defined [-Werror]
 inline dpvs_tick_t timeval_to_ticks(const struct timeval *tv);
                    ^~~~~~~~~~~~~~~~
In file included from /tmp/dpvs/src//../include/inetaddr.h:25:0,
                 from /tmp/dpvs/src//../include/netif.h:23,
                 from /tmp/dpvs/src/ipv4_frag.c:23:
/tmp/dpvs/src//../include/timer.h:54:13: error: inline function ‘ticks_to_timeval’ declared but never defined [-Werror]
 inline void ticks_to_timeval(const dpvs_tick_t ticks, struct timeval *tv);
             ^~~~~~~~~~~~~~~~
/tmp/dpvs/src//../include/timer.h:53:20: error: inline function ‘timeval_to_ticks’ declared but never defined [-Werror]
 inline dpvs_tick_t timeval_to_ticks(const struct timeval *tv);
                    ^~~~~~~~~~~~~~~~
In file included from /tmp/dpvs/src//../include/inetaddr.h:25:0,
                 from /tmp/dpvs/src//../include/netif.h:23,
                 from /tmp/dpvs/src//../include/ipset.h:26,
                 from /tmp/dpvs/src/ipset.c:24:
/tmp/dpvs/src//../include/timer.h:54:13: error: inline function ‘ticks_to_timeval’ declared but never defined [-Werror]
 inline void ticks_to_timeval(const dpvs_tick_t ticks, struct timeval *tv);
             ^~~~~~~~~~~~~~~~
/tmp/dpvs/src//../include/timer.h:53:20: error: inline function ‘timeval_to_ticks’ declared but never defined [-Werror]
 inline dpvs_tick_t timeval_to_ticks(const struct timeval *tv);
                    ^~~~~~~~~~~~~~~~

```

This is because of these inline methods definitions put in different places.