### PR TITLE
ipvs: move dp_vs_get_conn_timeout() from ipvs service module into ipvs

### DIFF
--- a/include/ipvs/conn.h
+++ b/include/ipvs/conn.h
@@ -335,6 +335,7 @@ uint32_t dp_vs_conn_hashkey(int af,
     uint32_t mask);
 int dp_vs_conn_pool_size(void);
 int dp_vs_conn_pool_cache_size(void);
+unsigned dp_vs_conn_get_persist_timeout(struct dp_vs_conn *conn);
 
 extern bool dp_vs_redirect_disable;
 

--- a/include/ipvs/service.h
+++ b/include/ipvs/service.h
@@ -112,6 +112,4 @@ struct dp_vs_service *dp_vs_vip_lookup(int af, uint16_t protocol,
                                        const union inet_addr *vaddr,
                                        lcoreid_t cid);
 
-unsigned dp_vs_get_conn_timeout(struct dp_vs_conn *conn);
-
 #endif /* __DPVS_SVC_H__ */

--- a/src/ipvs/ip_vs_conn.c
+++ b/src/ipvs/ip_vs_conn.c
@@ -489,6 +489,18 @@ static inline void conn_stats_dump(const char *msg, struct dp_vs_conn *conn)
 
 static void dp_vs_conn_put_nolock(struct dp_vs_conn *conn);
 
+unsigned dp_vs_conn_get_persist_timeout(struct dp_vs_conn *conn)
+{
+    unsigned conn_timeout;
+
+    if (conn->dest) {
+        conn_timeout = conn->dest->conn_timeout;
+        return conn_timeout;
+    }
+
+    return 90;
+}
+
 static void dp_vs_conn_set_timeout(struct dp_vs_conn *conn,
                                    struct dp_vs_proto *pp)
 {
@@ -497,7 +509,7 @@ static void dp_vs_conn_set_timeout(struct dp_vs_conn *conn,
     /* set proper timeout */
     if ((conn->proto == IPPROTO_TCP && conn->state == DPVS_TCP_S_ESTABLISHED)
         || (conn->proto == IPPROTO_UDP && conn->state == DPVS_UDP_S_NORMAL)) {
-        conn_timeout = dp_vs_get_conn_timeout(conn);
+        conn_timeout = dp_vs_conn_get_persist_timeout(conn);
 
         if (unlikely(conn_timeout > 0)) {
             conn->timeout.tv_sec = conn_timeout;

--- a/src/ipvs/ip_vs_proto_tcp.c
+++ b/src/ipvs/ip_vs_proto_tcp.c
@@ -899,7 +899,7 @@ tcp_state_out:
     conn->state = new_state;
 
     if (new_state == DPVS_TCP_S_ESTABLISHED) {
-        conn_timeout = dp_vs_get_conn_timeout(conn);
+        conn_timeout = dp_vs_conn_get_persist_timeout(conn);
         if (unlikely(conn_timeout > 0))
             conn->timeout.tv_sec = conn_timeout;
         else

--- a/src/ipvs/ip_vs_service.c
+++ b/src/ipvs/ip_vs_service.c
@@ -755,17 +755,6 @@ out:
     return ret;
 }
 
-
-unsigned dp_vs_get_conn_timeout(struct dp_vs_conn *conn)
-{
-    unsigned conn_timeout;
-    if (conn->dest) {
-        conn_timeout = conn->dest->conn_timeout;
-        return conn_timeout;
-    }
-    return 90;
-}
-
 static int dp_vs_services_flush(lcoreid_t cid)
 {
     int idx;

--- a/src/ipvs/ip_vs_synproxy.c
+++ b/src/ipvs/ip_vs_synproxy.c
@@ -1218,7 +1218,7 @@ int dp_vs_synproxy_synack_rcv(struct rte_mbuf *mbuf, struct dp_vs_conn *cp,
             (cp->state == DPVS_TCP_S_SYN_SENT)) {
         cp->syn_proxy_seq.delta = ntohl(cp->syn_proxy_seq.isn) - ntohl(th->seq);
         cp->state = DPVS_TCP_S_ESTABLISHED;
-        conn_timeout = dp_vs_get_conn_timeout(cp);
+        conn_timeout = dp_vs_conn_get_persist_timeout(cp);
         if (unlikely((conn_timeout != 0) && (cp->proto == IPPROTO_TCP)))
             cp->timeout.tv_sec = conn_timeout;
         else


### PR DESCRIPTION
connection module.

- Additionally, rename dp_vs_get_conn_timeout() to dp_vs_conn_get_persist_timeout().