### PR TITLE
dpvs: fix problem that dpvs crash when cpu id is larger than cpu cnt.

### DIFF
--- a/include/global_data.h
+++ b/include/global_data.h
@@ -50,6 +50,7 @@ extern dpvs_lcore_role_t g_lcore_role[DPVS_MAX_LCORE];
  *  anything else       -1
  * */
 extern int g_lcore_index[DPVS_MAX_LCORE];
+extern int g_lcore_num;
 
 int global_data_init(void);
 int global_data_term(void);

--- a/src/global_data.c
+++ b/src/global_data.c
@@ -23,12 +23,14 @@
 uint64_t g_cycles_per_sec;
 dpvs_lcore_role_t g_lcore_role[DPVS_MAX_LCORE];
 int g_lcore_index[DPVS_MAX_LCORE];
+int g_lcore_num;
 
 int global_data_init(void)
 {
     int i;
 
     g_cycles_per_sec = rte_get_timer_hz();
+    g_lcore_num = 0;
 
     for (i = 0; i < DPVS_MAX_LCORE; i++) {
         g_lcore_role[i] = LCORE_ROLE_IDLE;

--- a/src/netif.c
+++ b/src/netif.c
@@ -1276,6 +1276,8 @@ static void build_lcore_index(void)
     for (i = 0; i < DPVS_MAX_LCORE; i++)
         if (g_lcore_role[i] == LCORE_ROLE_ISOLRX_WORKER)
             g_lcore_index[idx++] = i;
+
+    g_lcore_num = idx;
 }
 
 static void lcore_role_init(void)


### PR DESCRIPTION
dpvs will be crashed when ipvsadm -ln --cpu M while max cpu cnt = N(M>=N).