### PR TITLE
dpvs: fix the problem of  showing the laddr info of  a slave worker

### DIFF
--- a/src/ipvs/ip_vs_laddr.c
+++ b/src/ipvs/ip_vs_laddr.c
@@ -525,6 +525,7 @@ static int get_msg_cb(struct dpvs_msg *msg)
 
     *laddrs = *laddr_conf;
     laddrs->nladdrs = naddr;
+    laddrs->cid = cid;
     for (i = 0; i < naddr; i++) {
         laddrs->laddrs[i].af = addrs[i].af;
         laddrs->laddrs[i].addr = addrs[i].addr;


### PR DESCRIPTION
dpvs return the error log "SERVICE: laddr_sockopt_get: find no laddr for cid=2" in the function laddr_sockopt_get because of the different cid  when executing ipvsadm -G --cpu N (N > 0, which is the cpu index of a slave worker).
