### PR TITLE
fix the bug that blklst configuration multicast msg send fail

### DIFF
--- a/src/inetaddr.c
+++ b/src/inetaddr.c
@@ -1132,7 +1132,7 @@ static int ifa_msg_get_cb(struct dpvs_msg *msg)
 
     if (!msg || (msg->len && msg->len != sizeof(idev)))
         return EDPVS_INVAL;
-    ptr = msg->len ? (void*)msg->data : NULL;
+    ptr = msg->len ? (void *)msg->data : NULL;
     idev = ptr ? (*(struct inet_device **)ptr) : NULL;
 
     if (idev)

--- a/src/ipvs/ip_vs_blklst.c
+++ b/src/ipvs/ip_vs_blklst.c
@@ -117,6 +117,12 @@ static int dp_vs_blklst_del_lcore(int af, uint8_t proto, const union inet_addr *
     return EDPVS_NOTEXIST;
 }
 
+static uint32_t blklst_msg_seq(void)
+{
+    static uint32_t counter = 0;
+    return counter++;
+}
+
 static int dp_vs_blklst_add(int af, uint8_t proto, const union inet_addr *vaddr,
                             uint16_t vport, const union inet_addr *blklst)
 {
@@ -145,7 +151,7 @@ static int dp_vs_blklst_add(int af, uint8_t proto, const union inet_addr *vaddr,
     }
 
     /*set blklst ip on all slave lcores*/
-    msg = msg_make(MSG_TYPE_BLKLST_ADD, 0, DPVS_MSG_MULTICAST,
+    msg = msg_make(MSG_TYPE_BLKLST_ADD, blklst_msg_seq(), DPVS_MSG_MULTICAST,
                    cid, sizeof(struct dp_vs_blklst_conf), &cf);
     if (unlikely(!msg))
         return EDPVS_NOMEM;
@@ -188,7 +194,7 @@ static int dp_vs_blklst_del(int af, uint8_t proto, const union inet_addr *vaddr,
     }
 
     /*del blklst ip on all slave lcores*/
-    msg = msg_make(MSG_TYPE_BLKLST_DEL, 0, DPVS_MSG_MULTICAST,
+    msg = msg_make(MSG_TYPE_BLKLST_DEL, blklst_msg_seq(), DPVS_MSG_MULTICAST,
                    cid, sizeof(struct dp_vs_blklst_conf), &cf);
     if (!msg)
         return EDPVS_NOMEM;


### PR DESCRIPTION
1) fix the bug of blklst multicast msg send fail
configure multi blklst ip in keepalived.conf, only the first ip is configured successfully, the other blklst ip is configured failed because of the repeated sequence number in the function multicast_msg_send  when master send multicast msg to slave worker.

ps:  the error log as below
May 19 10:19:05 dpvs[32671]: MSGMGR: multicast_msg_send:msg@0x7f771710548c, repeated sequence number for multicast msg: type 9, seq 0
May 19 10:19:05 dpvs[32671]: SERVICE: [dp_vs_blklst_add] fail to send multicast message

2) adjust  format (void*)  to (void  *)