### PR TITLE
dpvs:fix the error of no memory by allocing memory without specific numa

### DIFF
--- a/src/iftraf.c
+++ b/src/iftraf.c
@@ -406,7 +406,7 @@ int iftraf_sockopt_get(sockoptid_t opt, const void *conf, size_t size,
                iftraf_sorted_list.sorted_list_num * sizeof(struct iftraf_param);
     *out = rte_calloc(NULL, 1, *outsize, RTE_CACHE_LINE_SIZE);
     if (!(*out)) {
-	RTE_LOG(ERR, IFTRAF, "%s: no memory \n", __func__);
+        RTE_LOG(ERR, IFTRAF, "%s: no memory \n", __func__);
         return EDPVS_NOMEM;
     }
 
@@ -903,12 +903,12 @@ static int iftraf_enable_func(void)
         return err;
     }
 
-    iftraf_tbl = rte_malloc_socket(NULL, sizeof(struct list_head) * IFTRAF_TBL_SIZE,
-                    RTE_CACHE_LINE_SIZE, rte_socket_id());
+    iftraf_tbl = rte_malloc(NULL, sizeof(struct list_head) * IFTRAF_TBL_SIZE,
+                    RTE_CACHE_LINE_SIZE);
 
     if (!iftraf_tbl) {
         RTE_LOG(ERR, IFTRAF,
-            "%s: rte_malloc_socket null\n",
+            "%s: rte_malloc null\n",
             __func__);
         goto tbl_fail;
     }
@@ -916,12 +916,12 @@ static int iftraf_enable_func(void)
     for (i = 0; i < IFTRAF_TBL_SIZE; i++)
         INIT_LIST_HEAD(&iftraf_tbl[i]);
 
-    iftraf_iftbl = rte_malloc_socket(NULL, sizeof(struct list_head) * IFTRAF_IFTBL_SIZE,
-                      RTE_CACHE_LINE_SIZE, rte_socket_id());
+    iftraf_iftbl = rte_malloc(NULL, sizeof(struct list_head) * IFTRAF_IFTBL_SIZE,
+                      RTE_CACHE_LINE_SIZE);
 
     if (!iftraf_iftbl) {
         RTE_LOG(ERR, IFTRAF,
-            "%s: rte_malloc_socket null\n",
+            "%s: rte_malloc null\n",
             __func__);
         goto iftbl_fail;
     }

--- a/src/ipset.c
+++ b/src/ipset.c
@@ -240,7 +240,7 @@ static int ipset_sockopt_get(sockoptid_t opt, const void *conf, size_t size,
     nips = this_num_ipset;
     *outsize = sizeof(struct dp_vs_ipset_conf_array) + \
                    nips * sizeof(struct dp_vs_ipset_conf);
-    *out = rte_calloc_socket(NULL, 1, *outsize, 0, rte_socket_id());
+    *out = rte_calloc(NULL, 1, *outsize, 0);
     if (!(*out))
         return EDPVS_NOMEM;
     array = *out;
@@ -356,7 +356,7 @@ static int ipset_parse_conf_file(void)
     fseek(g_current_stream, 0, SEEK_SET);
 
     ipset_size = sizeof(struct dp_vs_multi_ipset_conf) + ip_num*sizeof(struct dp_vs_ipset_conf);
-    ips = rte_calloc_socket(NULL, 1, ipset_size, 0, rte_socket_id());
+    ips = rte_calloc(NULL, 1, ipset_size, 0);
     if (ips == NULL) {
         RTE_LOG(WARNING, IPSET, "no memory for ipset conf\n");
         FREE(buf);

--- a/src/ipv6/route6_hlist.c
+++ b/src/ipv6/route6_hlist.c
@@ -176,7 +176,7 @@ static int rt6_hlist_add_lcore(const struct dp_vs_route6_conf *cf)
 
         nbuckets = rt6_hlist_buckets(cf->dst.plen);
         size = sizeof(struct rt6_hlist) + nbuckets * sizeof(struct list_head);
-        new_hlist = rte_zmalloc_socket("rt6_hlist", size, 0, rte_socket_id());
+        new_hlist = rte_zmalloc("rt6_hlist", size, 0);
         if (unlikely(!new_hlist)) {
             RTE_LOG(ERR, RT6, "[%d] %s: fail to alloc rt6_hlist\n",
                     rte_lcore_id(), __func__);
@@ -201,7 +201,7 @@ static int rt6_hlist_add_lcore(const struct dp_vs_route6_conf *cf)
     }
 
     /* create route6 entry and hash it into current hlist */
-    rt6 = rte_zmalloc_socket("rt6_entry", sizeof(struct route6), 0, rte_socket_id());
+    rt6 = rte_zmalloc("rt6_entry", sizeof(struct route6), 0);
     if (unlikely(!rt6)) {
         RTE_LOG(ERR, RT6, "[%d] %s: fail to alloc rt6_entry!\n",
                 rte_lcore_id(), __func__);
@@ -334,9 +334,12 @@ static struct dp_vs_route6_conf_array*
 
     *nbytes = sizeof(struct dp_vs_route6_conf_array) +
             g_nroutes * sizeof(struct dp_vs_route6_conf);
-    rt6_arr = rte_zmalloc_socket("rt6_sockopt_get", *nbytes, 0, rte_socket_id());
-    if (unlikely(!rt6_arr))
+    rt6_arr = rte_zmalloc("rt6_sockopt_get", *nbytes, 0);
+    if (unlikely(!rt6_arr)) {
+        RTE_LOG(WARNING, RT6, "%s: rte_zmalloc null.\n",
+            __func__);
         return NULL;
+    }
 
     off = 0;
     list_for_each_entry(hlist, &this_rt6_htable, node) {

--- a/src/ipv6/route6_lpm.c
+++ b/src/ipv6/route6_lpm.c
@@ -127,15 +127,15 @@ static int rt6_lpm_setup_lcore(void *arg)
 
     this_rt6_default = NULL;
 
-    this_rt6_array = rte_zmalloc_socket("rt6_array",
-            sizeof(struct rt6_array)+sizeof(void*)*g_rt6_array_size, 0, socketid);
+    this_rt6_array = rte_zmalloc("rt6_array",
+            sizeof(struct rt6_array)+sizeof(void*)*g_rt6_array_size, 0);
     if (unlikely(this_rt6_array == NULL)) {
         RTE_LOG(ERR, RT6, "%s: no memory to create rt6_array!", __func__);
         return EDPVS_NOMEM;
     }
 
-    this_rt6_hash = rte_zmalloc_socket("rt6_hash",
-            sizeof(struct list_head)*g_rt6_hash_bucket, 0, socketid);
+    this_rt6_hash = rte_zmalloc("rt6_hash",
+            sizeof(struct list_head)*g_rt6_hash_bucket, 0);
     if (unlikely(this_rt6_hash == NULL)) {
         ret = EDPVS_NOMEM;
         goto rt6_hash_fail;
@@ -281,7 +281,7 @@ static int rt6_add_lcore_default(const struct dp_vs_route6_conf *rt6_cfg)
     if (this_rt6_default)
         return EDPVS_EXIST;
 
-    entry = rte_zmalloc_socket("rt6_entry", sizeof(struct route6), 0, rte_socket_id());
+    entry = rte_zmalloc("rt6_entry", sizeof(struct route6), 0);
     if (unlikely(entry == NULL))
         return EDPVS_NOMEM;
 
@@ -333,7 +333,7 @@ static int rt6_lpm_add_lcore(const struct dp_vs_route6_conf *rt6_cfg)
     if (unlikely(ret != EDPVS_OK))
         goto rt6_add_fail;
 
-    entry = rte_zmalloc_socket("rt6_entry", sizeof(struct route6), 0, rte_socket_id());
+    entry = rte_zmalloc("rt6_entry", sizeof(struct route6), 0);
     if (unlikely(entry == NULL)) {
         ret = EDPVS_NOMEM;
         goto rt6_add_fail;
@@ -443,9 +443,12 @@ static struct dp_vs_route6_conf_array *rt6_lpm_dump(
     else
         *nbytes = sizeof(struct dp_vs_route6_conf_array) +\
                   (g_nroutes) * sizeof(struct dp_vs_route6_conf);
-    rt6_arr = rte_zmalloc_socket("rt6_sockopt_get", *nbytes, 0, rte_socket_id());
-    if (unlikely(!rt6_arr))
+    rt6_arr = rte_zmalloc("rt6_sockopt_get", *nbytes, 0);
+    if (unlikely(!rt6_arr)) {
+        RTE_LOG(WARNING, RT6, "%s: rte_zmalloc null!\n",
+            __func__);
         return NULL;
+    }
 
     off = 0;
     for (i = 0; i < g_rt6_hash_bucket; i++) {

--- a/src/ipvs/ip_vs_blklst.c
+++ b/src/ipvs/ip_vs_blklst.c
@@ -140,7 +140,7 @@ static int dp_vs_blklst_add(int af, uint8_t proto, const union inet_addr *vaddr,
     /*set blklst ip on master lcore*/
     err = dp_vs_blklst_add_lcore(af, proto, vaddr, vport, blklst);
     if (err) {
-        RTE_LOG(INFO, SERVICE, "[%s] fail to set blklst ip\n", __func__);
+        RTE_LOG(INFO, SERVICE, "[%s] fail to set blklst ip -- %s\n", __func__, dpvs_strerror(err));
         return err;
     }
 
@@ -183,7 +183,7 @@ static int dp_vs_blklst_del(int af, uint8_t proto, const union inet_addr *vaddr,
     /*del blklst ip on master lcores*/
     err = dp_vs_blklst_del_lcore(af, proto, vaddr, vport, blklst);
     if (err) {
-        RTE_LOG(INFO, SERVICE, "%s: fail to del blklst ip\n", __func__);
+        RTE_LOG(INFO, SERVICE, "%s: fail to del blklst ip -- %s\n", __func__, dpvs_strerror(err));
         return err;
     }
 
@@ -284,7 +284,7 @@ static int blklst_sockopt_get(sockoptid_t opt, const void *conf, size_t size,
     naddr = rte_atomic32_read(&this_num_blklsts);
     *outsize = sizeof(struct dp_vs_blklst_conf_array) +
                naddr * sizeof(struct dp_vs_blklst_conf);
-    *out = rte_calloc_socket(NULL, 1, *outsize, 0, rte_socket_id());
+    *out = rte_calloc(NULL, 1, *outsize, 0);
     if (!(*out))
         return EDPVS_NOMEM;
     array = *out;
@@ -350,9 +350,9 @@ static int blklst_lcore_init(void *args)
     int i;
     if (!rte_lcore_is_enabled(rte_lcore_id()))
     return EDPVS_DISABLED;
-    this_blklst_tab = rte_malloc_socket(NULL,
+    this_blklst_tab = rte_malloc(NULL,
                         sizeof(struct list_head) * DPVS_BLKLST_TAB_SIZE,
-                        RTE_CACHE_LINE_SIZE, rte_socket_id());
+                        RTE_CACHE_LINE_SIZE);
     if (!this_blklst_tab)
         return EDPVS_NOMEM;
 

--- a/src/ipvs/ip_vs_conn.c
+++ b/src/ipvs/ip_vs_conn.c
@@ -1148,9 +1148,9 @@ static int conn_init_lcore(void *arg)
     if (netif_lcore_is_idle(rte_lcore_id()))
         return EDPVS_IDLE;
 
-    this_conn_tbl = rte_malloc_socket(NULL,
+    this_conn_tbl = rte_malloc(NULL,
                         sizeof(struct list_head) * DPVS_CONN_TBL_SIZE,
-                        RTE_CACHE_LINE_SIZE, rte_socket_id());
+                        RTE_CACHE_LINE_SIZE);
     if (!this_conn_tbl)
         return EDPVS_NOMEM;
 
@@ -1725,8 +1725,14 @@ int dp_vs_conn_init(void)
     char poolname[32];
 
     /* init connection template table */
-    dp_vs_ct_tbl = rte_malloc_socket(NULL, sizeof(struct list_head) * DPVS_CONN_TBL_SIZE,
-            RTE_CACHE_LINE_SIZE, rte_socket_id());
+    dp_vs_ct_tbl = rte_malloc(NULL, sizeof(struct list_head) * DPVS_CONN_TBL_SIZE,
+            RTE_CACHE_LINE_SIZE);
+    if (!dp_vs_ct_tbl) {
+        err = EDPVS_NOMEM;
+        RTE_LOG(WARNING, IPVS, "%s: %s.\n",
+            __func__, dpvs_strerror(err));
+        return err;
+    }
 
     for (i = 0; i < DPVS_CONN_TBL_SIZE; i++)
         INIT_LIST_HEAD(&dp_vs_ct_tbl[i]);

--- a/src/ipvs/ip_vs_laddr.c
+++ b/src/ipvs/ip_vs_laddr.c
@@ -307,8 +307,8 @@ int dp_vs_laddr_add(struct dp_vs_service *svc,
     if (!svc || !addr)
         return EDPVS_INVAL;
 
-    new = rte_malloc_socket(NULL, sizeof(*new),
-                            RTE_CACHE_LINE_SIZE, rte_socket_id());
+    new = rte_malloc(NULL, sizeof(*new),
+                            RTE_CACHE_LINE_SIZE);
     if (!new)
         return EDPVS_NOMEM;
 
@@ -373,8 +373,8 @@ static int dp_vs_laddr_getall(struct dp_vs_service *svc,
 
     if (svc->num_laddrs > 0) {
         *naddr = svc->num_laddrs;
-        *addrs = rte_malloc_socket(0, sizeof(struct dp_vs_laddr_entry) * svc->num_laddrs,
-                RTE_CACHE_LINE_SIZE, rte_socket_id());
+        *addrs = rte_malloc(0, sizeof(struct dp_vs_laddr_entry) * svc->num_laddrs,
+                RTE_CACHE_LINE_SIZE);
         if (!(*addrs)) {
             return EDPVS_NOMEM;
         }
@@ -630,7 +630,7 @@ static int laddr_sockopt_get(sockoptid_t opt, const void *conf, size_t size,
                 }
                 
                 *outsize = sizeof(*laddr_conf) + naddr * sizeof(struct dp_vs_laddr_entry);
-                *out = rte_malloc_socket(0, *outsize, RTE_CACHE_LINE_SIZE, rte_socket_id());
+                *out = rte_malloc(0, *outsize, RTE_CACHE_LINE_SIZE);
                 if (!*out) {
                     if (addrs)
                         rte_free(addrs);
@@ -671,7 +671,7 @@ static int laddr_sockopt_get(sockoptid_t opt, const void *conf, size_t size,
                     if (cid == get_msg->cid) {
                         *outsize = sizeof(*laddr_conf) + \
                                    get_msg->nladdrs * sizeof(struct dp_vs_laddr_entry);
-                        *out = rte_malloc_socket(0, *outsize, RTE_CACHE_LINE_SIZE, rte_socket_id());
+                        *out = rte_malloc(0, *outsize, RTE_CACHE_LINE_SIZE);
                         if (!*out) {
                             msg_destroy(&msg);
                             return EDPVS_NOMEM;

--- a/src/ipvs/ip_vs_redirect.c
+++ b/src/ipvs/ip_vs_redirect.c
@@ -314,8 +314,8 @@ static int dp_vs_redirect_table_create(void)
 
     /* allocate the global redirect hash table, per socket? */
     dp_vs_cr_tbl =
-        rte_malloc_socket(NULL, sizeof(struct list_head ) * DPVS_CR_TBL_SIZE,
-                          RTE_CACHE_LINE_SIZE, rte_socket_id());
+        rte_malloc(NULL, sizeof(struct list_head ) * DPVS_CR_TBL_SIZE,
+                          RTE_CACHE_LINE_SIZE);
     if (!dp_vs_cr_tbl) {
         goto cache_free;
     }

--- a/src/route.c
+++ b/src/route.c
@@ -626,7 +626,7 @@ static int route_sockopt_get(sockoptid_t opt, const void *conf, size_t size,
 
     *outsize = sizeof(struct dp_vs_route_conf_array) + \
                nroute * sizeof(struct dp_vs_route_conf);
-    *out = rte_calloc_socket(NULL, 1, *outsize, 0, rte_socket_id());
+    *out = rte_calloc(NULL, 1, *outsize, 0);
     if (!(*out))
         return EDPVS_NOMEM;
     array = *out;


### PR DESCRIPTION
dpvs:fix the error of no memory by allocing memory without specific numa.
eg:  
we use the funciton rte_zmalloc without specific numa to add a ipv4 route in the function route_sockopt_set, while using the function  rte_calloc_socket to alloc memory in the function route_sockopt_get, which maybe casue the no memory error.
so use rte_malloc instand of rte_malloc_socket,  rte_zmalloc instand of rte_zmalloc_socket, rte_calloc instand of rte_calloc_socket.