### PR TITLE
dpvs: fix the dpvs msg memory leak

### DIFF
--- a/src/ipvs/ip_vs_blklst.c
+++ b/src/ipvs/ip_vs_blklst.c
@@ -194,6 +194,7 @@ static int dp_vs_blklst_del(int af, uint8_t proto, const union inet_addr *vaddr,
         return EDPVS_NOMEM;
     err = multicast_msg_send(msg, DPVS_MSG_F_ASYNC, NULL);
     if (err != EDPVS_OK) {
+        msg_destroy(&msg);
         RTE_LOG(INFO, SERVICE, "%s: fail to send multicast message\n", __func__);
         return err;
     }


### PR DESCRIPTION
dpvs: fix the dpvs msg memory leak in dp_vs_blklst_del