### PR TITLE
dpvs: fix the conhash no memory problem

### DIFF
--- a/include/ipvs/sched.h
+++ b/include/ipvs/sched.h
@@ -50,6 +50,8 @@ int dp_vs_bind_scheduler(struct dp_vs_service *svc,
 
 int dp_vs_unbind_scheduler(struct dp_vs_service *svc);
 
+int dp_vs_gcd_weight(struct dp_vs_service *svc);
+
 void dp_vs_scheduler_put(struct dp_vs_scheduler *scheduler);
 
 int register_dp_vs_scheduler(struct dp_vs_scheduler *scheduler);

--- a/include/ipvs/service.h
+++ b/include/ipvs/service.h
@@ -41,6 +41,15 @@
 
 #define DP_VS_SVC_F_MATCH           0x0400      /* snat match */
 
+#define DP_VS_MAX_RS_NUM_PER_SVC    (2048)      /* max rs num per svc */
+
+/**
+ * hash table for svc
+ */
+#define DP_VS_SVC_TAB_BITS 8
+#define DP_VS_SVC_TAB_SIZE (1 << DP_VS_SVC_TAB_BITS)
+#define DP_VS_SVC_TAB_MASK (DP_VS_SVC_TAB_SIZE - 1)
+
 /* virtual service */
 struct dp_vs_service {
     struct list_head    s_list;     /* node for normal service table */
@@ -74,7 +83,7 @@ struct dp_vs_service {
     long                weight;     /* sum of servers weight */
 
     struct dp_vs_scheduler  *scheduler;
-    void                *sched_data;
+    void                *sched_data[2];
 
     struct dp_vs_stats  stats;
 
@@ -89,6 +98,8 @@ struct dp_vs_service {
 
 int dp_vs_service_init(void);
 int dp_vs_service_term(void);
+
+int dp_vs_service_hashkey(int af, unsigned proto, const union inet_addr *addr);
 
 struct dp_vs_service *
 dp_vs_service_lookup(int af, uint16_t protocol,

--- a/src/ipvs/ip_vs_conhash.c
+++ b/src/ipvs/ip_vs_conhash.c
@@ -469,8 +469,8 @@ static int dp_vs_conhash_init_svc(struct dp_vs_service *svc)
     if (!svc_data) {
         if (rte_get_master_lcore() == cid) {
             // only master lcore comes here.
-            RTE_LOG(DEBUG, SERVICE, "[%d]%s: conhash init svc get svc data failed, creating\n",
-                        __func__);
+            RTE_LOG(DEBUG, SERVICE, "[%d] %s: conhash init svc get svc data failed, creating\n",
+                        cid, __func__);
             ret = dp_vs_conhash_create_svc_data(svc, &svc_data);
             if (EDPVS_OK != ret) {
                 rte_free(rs_data);

--- a/src/ipvs/ip_vs_dest.c
+++ b/src/ipvs/ip_vs_dest.c
@@ -123,6 +123,12 @@ dp_vs_dest_add(struct dp_vs_service *svc, struct dp_vs_dest_conf *udest)
         return EDPVS_NOTSUPP;
     }
 
+    if (svc->num_dests >= DP_VS_MAX_RS_NUM_PER_SVC) {
+        RTE_LOG(ERR, SERVICE, "%s: dest num of svc is %d, exceed the limit of %d.\n",
+               __func__, svc->num_dests, DP_VS_MAX_RS_NUM_PER_SVC);
+        return EDPVS_OVERLOAD;
+    }
+
     daddr = udest->addr;
 
     /*

--- a/src/ipvs/ip_vs_rr.c
+++ b/src/ipvs/ip_vs_rr.c
@@ -20,14 +20,14 @@
 
 static int dp_vs_rr_init_svc(struct dp_vs_service *svc)
 {
-    svc->sched_data = &svc->dests;
+    svc->sched_data[0] = &svc->dests;
     return EDPVS_OK;
 }
 
 static int dp_vs_rr_update_svc(struct dp_vs_service *svc,
         struct dp_vs_dest *dest __rte_unused, sockoptid_t opt __rte_unused)
 {
-    svc->sched_data = &svc->dests;
+    svc->sched_data[0] = &svc->dests;
     return EDPVS_OK;
 }
 
@@ -40,7 +40,7 @@ static struct dp_vs_dest *dp_vs_rr_schedule(struct dp_vs_service *svc,
     struct list_head *p, *q;
     struct dp_vs_dest *dest;
 
-    p = (struct list_head *)svc->sched_data;
+    p = (struct list_head *)svc->sched_data[0];
     p = p->next;
     q = p;
 
@@ -61,7 +61,7 @@ static struct dp_vs_dest *dp_vs_rr_schedule(struct dp_vs_service *svc,
     return NULL;
 
 out:
-    svc->sched_data = q;
+    svc->sched_data[0] = q;
 
     return dest;
 }

--- a/src/ipvs/ip_vs_sched.c
+++ b/src/ipvs/ip_vs_sched.c
@@ -87,6 +87,41 @@ int dp_vs_unbind_scheduler(struct dp_vs_service *svc)
 }
 
 /*
+ *  Get the gcd of server weights
+ */
+static int gcd(int a, int b)
+{
+    int c;
+
+    while ((c = a % b)) {
+        a = b;
+        b = c;
+    }
+    return b;
+}
+
+/*
+ *  get the gcd weight of dests in svc
+ */
+int dp_vs_gcd_weight(struct dp_vs_service *svc)
+{
+    struct dp_vs_dest *dest;
+    int weight;
+    int g = 0;
+
+    list_for_each_entry(dest, &svc->dests, n_list) {
+        weight = rte_atomic16_read(&dest->weight);
+        if (weight > 0) {
+            if (g > 0)
+                g = gcd(weight, g);
+            else
+                g = weight;
+        }
+    }
+    return g ? g : 1;
+}
+
+/*
  *  Lookup scheduler and try to load it if it doesn't exist
  */
 struct dp_vs_scheduler *dp_vs_scheduler_get(const char *sched_name)


### PR DESCRIPTION
If we create more vs with conhash scheduler, the memory will be a big problem .
The changes are as follows in this commit:
1> Use weight ratio instead of weight to reduce the num of virtual node in the conhash rbtree.
2> Only build rbtree in the master lcore.
3> Set the maximum number of rs under per vs;