### PR TITLE
dpip: show dpdk mem info

### DIFF
--- a/include/conf/eal_mem.h
+++ b/include/conf/eal_mem.h
@@ -1,0 +1,100 @@
+/*
+ * DPVS is a software load balancer (Virtual Server) based on DPDK.
+ *
+ * Copyright (C) 2017 iQIYI (www.iqiyi.com).
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+#ifndef __DPVS_EAL_MEM_CONF__
+#define __DPVS_EAL_MEM_CONF__
+
+#include <stdio.h>
+#include <string.h>
+
+#define EAL_MEM_NAME_LEN        (32)
+
+enum {
+    /* set */
+    SOCKOPT_SET_EAL_MEM_NONE = 7400,
+
+    /* get */
+    SOCKOPT_GET_EAL_MEM_SEG ,
+    SOCKOPT_GET_EAL_MEM_ZONE,
+    SOCKOPT_GET_EAL_MEM_RING,
+    SOCKOPT_GET_EAL_MEM_POOL,
+};
+
+typedef struct eal_mem_seg_ret_s {
+    uint64_t phys_addr;
+    uint64_t virt_addr;
+    uint64_t len;
+    uint64_t hugepage_sz;
+    int socket_id;
+    uint32_t nchannel;
+    uint32_t nrank;
+    uint64_t free_seg_len;
+} eal_mem_seg_ret_t;
+
+typedef struct eal_all_mem_seg_ret_s {
+    uint32_t seg_num;
+    eal_mem_seg_ret_t seg_info[0];
+} eal_all_mem_seg_ret_t;
+
+typedef struct eal_mem_zone_ret_s {
+    char name[EAL_MEM_NAME_LEN];
+    uint64_t phys_addr;
+    uint64_t virt_addr;
+    uint64_t len;
+    uint64_t hugepage_sz;
+    int     socket_id;
+} eal_mem_zone_ret_t;
+
+typedef struct eal_all_mem_zone_ret_s {
+    uint32_t zone_num;
+    eal_mem_zone_ret_t zone_info[0];
+} eal_all_mem_zone_ret_t;
+
+typedef struct eal_mem_pool_ret_s {
+    char name[EAL_MEM_NAME_LEN];
+    uint32_t flags;
+    uint32_t size;
+    uint32_t count;
+    uint32_t elt_size;
+    uint32_t header_size;
+    uint32_t trailer_size;
+    uint32_t private_data_size;
+} eal_mem_pool_ret_t;
+
+typedef struct eal_all_mem_pool_ret_s {
+    uint32_t mempool_num;
+    eal_mem_pool_ret_t mempool_info[0];
+} eal_all_mem_pool_ret_t;
+
+typedef struct eal_mem_ring_ret_s {
+    char name[EAL_MEM_NAME_LEN];
+    int     flags;
+    uint32_t size;
+    uint32_t cons_tail;
+    uint32_t cons_head;
+    uint32_t prod_tail;
+    uint32_t prod_head;
+    uint32_t used;
+    uint32_t avail;
+} eal_mem_ring_ret_t;
+
+typedef struct eal_all_mem_ring_ret_s {
+    uint32_t ring_num;
+    eal_mem_ring_ret_t ring_info[0];
+} eal_all_mem_ring_ret_t;
+
+#endif

--- a/include/eal_mem.h
+++ b/include/eal_mem.h
@@ -1,0 +1,24 @@
+/*
+ * DPVS is a software load balancer (Virtual Server) based on DPDK.
+ *
+ * Copyright (C) 2017 iQIYI (www.iqiyi.com).
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+#ifndef __EAL_MEM__
+#define __EAL_MEM__
+
+int eal_mem_init(void);
+int eal_mem_term(void); /* cleanup */
+
+#endif

--- a/src/eal_mem.c
+++ b/src/eal_mem.c
@@ -1,0 +1,284 @@
+/*
+ * DPVS is a software load balancer (Virtual Server) based on DPDK.
+ *
+ * Copyright (C) 2017 iQIYI (www.iqiyi.com).
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+
+#include <rte_mempool.h>
+#include <rte_errno.h>
+#include <rte_eal_memconfig.h>
+#include <rte_malloc.h>
+#include "conf/eal_mem.h"
+#include "eal_mem.h"
+#include "ctrl.h"
+
+#define MAX_SEGMENT_NUM         RTE_MAX_MEMSEG
+#define MAX_MEMZONE_NUM         RTE_MAX_MEMZONE
+
+static uint64_t eal_get_free_seg_len(int socket_id)
+{
+    uint64_t len = 0;
+    struct rte_malloc_socket_stats socket_stats;
+
+    if (socket_id < 0 || socket_id > RTE_MAX_NUMA_NODES)
+        return 0;
+
+    memset(&socket_stats, 0, sizeof(struct rte_malloc_socket_stats));
+    if (rte_malloc_get_socket_stats(socket_id, &socket_stats) != 0)
+        return 0;
+    len = socket_stats.heap_freesz_bytes;
+
+    return len;
+}
+
+static int dp_vs_get_eal_mem_seg(eal_all_mem_seg_ret_t *eal_mem_segs)
+{
+    const struct rte_mem_config *mcfg;
+    unsigned i = 0;
+    unsigned j = 0;
+
+    /* get pointer to global configuration */
+    mcfg = rte_eal_get_configuration()->mem_config;
+
+    eal_mem_segs->seg_num = 0;
+    for (i = 0; i < MAX_SEGMENT_NUM; i++) {
+        if (NULL == mcfg->memseg[i].addr) {
+            break;
+        }
+        j = eal_mem_segs->seg_num;
+        eal_mem_segs->seg_num++;
+        eal_mem_segs->seg_info[j].phys_addr = mcfg->memseg[i].phys_addr;
+        eal_mem_segs->seg_info[j].virt_addr = mcfg->memseg[i].addr_64;
+        eal_mem_segs->seg_info[j].len = mcfg->memseg[i].len;
+        eal_mem_segs->seg_info[j].hugepage_sz = mcfg->memseg[i].hugepage_sz;
+        eal_mem_segs->seg_info[j].socket_id = mcfg->memseg[i].socket_id;
+        eal_mem_segs->seg_info[j].nchannel = rte_memory_get_nchannel();
+        eal_mem_segs->seg_info[j].nrank = rte_memory_get_nrank();
+        eal_mem_segs->seg_info[j].free_seg_len = eal_get_free_seg_len(mcfg->memseg[i].socket_id);
+    }
+
+   return 0;
+}
+
+static int dp_vs_get_eal_mem_zone(eal_all_mem_zone_ret_t *eal_mem_zones)
+{
+    eal_mem_zone_ret_t *zone_ret;
+    struct rte_mem_config *mcfg;
+    unsigned i = 0;
+
+    /* get pointer to global configuration */
+    mcfg = rte_eal_get_configuration()->mem_config;
+
+    rte_rwlock_read_lock(&mcfg->mlock);
+    eal_mem_zones->zone_num = 0;
+    for (i = 0; i < MAX_MEMZONE_NUM; i++) {
+        if (NULL == mcfg->memzone[i].addr) {
+            break;
+        }
+        zone_ret = &eal_mem_zones->zone_info[eal_mem_zones->zone_num];
+        eal_mem_zones->zone_num++;
+        memcpy(zone_ret->name, mcfg->memzone[i].name, EAL_MEM_NAME_LEN);
+        zone_ret->phys_addr = mcfg->memzone[i].phys_addr;
+        zone_ret->virt_addr = mcfg->memzone[i].addr_64;
+        zone_ret->len = mcfg->memzone[i].len;
+        zone_ret->hugepage_sz = mcfg->memzone[i].hugepage_sz;
+        zone_ret->socket_id = mcfg->memzone[i].socket_id;
+    }
+    rte_rwlock_read_unlock(&mcfg->mlock);
+
+    return 0;
+}
+
+static int dp_vs_get_eal_mem_pool(eal_all_mem_pool_ret_t *eal_mem_pools)
+{
+    TAILQ_HEAD(rte_mempool_list, rte_tailq_entry);
+    eal_mem_pool_ret_t *mempool_ret;
+    const struct rte_mempool *mp = NULL;
+    struct rte_tailq_entry *te;
+    struct rte_mempool_list *mempool_list;
+
+    mempool_list = RTE_TAILQ_LOOKUP("RTE_MEMPOOL", rte_mempool_list);
+    if (NULL == mempool_list)
+        return -1;
+
+    rte_rwlock_read_lock(RTE_EAL_MEMPOOL_RWLOCK);
+    eal_mem_pools->mempool_num = 0;
+    TAILQ_FOREACH(te, mempool_list, next) {
+        mp = (struct rte_mempool *) te->data;
+        mempool_ret = &eal_mem_pools->mempool_info[eal_mem_pools->mempool_num];
+        eal_mem_pools->mempool_num++;
+        memcpy(mempool_ret->name, mp->name, EAL_MEM_NAME_LEN);
+        mempool_ret->flags = mp->flags;
+        mempool_ret->size = mp->size;
+        mempool_ret->count = rte_mempool_ops_get_count(mp);
+        mempool_ret->elt_size = mp->elt_size;
+        mempool_ret->header_size = mp->header_size;
+        mempool_ret->trailer_size = mp->trailer_size;
+        mempool_ret->private_data_size = mp->private_data_size;
+    }
+    rte_rwlock_read_unlock(RTE_EAL_MEMPOOL_RWLOCK);
+
+    return 0;
+}
+
+static int dp_vs_get_eal_mem_ring(eal_all_mem_ring_ret_t *eal_mem_rings)
+{
+    TAILQ_HEAD(rte_ring_list, rte_tailq_entry);
+    eal_mem_ring_ret_t *ring_ret;
+    const struct rte_tailq_entry *te;
+    struct rte_ring_list *ring_list;
+    const struct rte_ring *r = NULL;
+
+    ring_list = RTE_TAILQ_LOOKUP("RTE_RING", rte_ring_list);
+
+    rte_rwlock_read_lock(RTE_EAL_TAILQ_RWLOCK);
+    eal_mem_rings->ring_num = 0;
+    TAILQ_FOREACH(te, ring_list, next) {
+        r = (struct rte_ring *)te->data;
+        ring_ret = &eal_mem_rings->ring_info[eal_mem_rings->ring_num];
+        eal_mem_rings->ring_num++;
+        memcpy(ring_ret->name, r->name, EAL_MEM_NAME_LEN);
+        ring_ret->flags = r->flags;
+        ring_ret->size = r->size;
+        ring_ret->cons_tail = r->cons.tail;
+        ring_ret->cons_head = r->cons.head;
+        ring_ret->prod_tail = r->prod.tail;
+        ring_ret->prod_head = r->prod.head;
+        ring_ret->used = rte_ring_count(r);
+        ring_ret->avail = rte_ring_free_count(r);
+    }
+    rte_rwlock_read_unlock(RTE_EAL_TAILQ_RWLOCK);
+
+    return 0;
+}
+
+static int dp_vs_eal_mem_get(sockoptid_t opt, const void *user, size_t len,
+                void **out, size_t *outlen)
+{
+    eal_all_mem_seg_ret_t *all_eal_mem_seg_ret = NULL;
+    eal_all_mem_zone_ret_t *all_eal_mem_zone_ret = NULL;
+    eal_all_mem_pool_ret_t *all_eal_mem_pool_ret = NULL;
+    eal_all_mem_ring_ret_t *all_eal_mem_ring_ret = NULL;
+    int size = 0;
+    int ret = EDPVS_OK;
+
+    if (!out || !outlen)
+        return EDPVS_INVAL;
+
+    switch(opt) {
+        case SOCKOPT_GET_EAL_MEM_SEG:
+            size = sizeof(eal_all_mem_seg_ret_t) +
+                    MAX_SEGMENT_NUM * sizeof(eal_mem_seg_ret_t);
+            all_eal_mem_seg_ret = rte_zmalloc("mem_seg", size, 0);
+            if (unlikely(!all_eal_mem_seg_ret)) {
+                ret = EDPVS_NOMEM;
+                return ret;
+            }
+            if (dp_vs_get_eal_mem_seg(all_eal_mem_seg_ret) < 0) {
+                ret = EDPVS_DPDKAPIFAIL;
+                rte_free(all_eal_mem_seg_ret);
+                all_eal_mem_seg_ret = NULL;
+                return ret;
+            }
+            *out = all_eal_mem_seg_ret;
+            *outlen = sizeof(eal_all_mem_seg_ret_t) +
+                    all_eal_mem_seg_ret->seg_num * sizeof(eal_mem_seg_ret_t);
+            break;
+
+        case SOCKOPT_GET_EAL_MEM_ZONE:
+            size = sizeof(eal_all_mem_zone_ret_t) +
+                    MAX_MEMZONE_NUM * sizeof(eal_mem_zone_ret_t);
+            all_eal_mem_zone_ret = rte_zmalloc("mem_zone", size, 0);
+            if (unlikely(!all_eal_mem_zone_ret)) {
+                ret = EDPVS_NOMEM;
+                return ret;
+            }
+            if (dp_vs_get_eal_mem_zone(all_eal_mem_zone_ret) < 0) {
+                ret = EDPVS_DPDKAPIFAIL;
+                rte_free(all_eal_mem_zone_ret);
+                all_eal_mem_zone_ret = NULL;
+                return ret;
+            }
+            *out = all_eal_mem_zone_ret;
+            *outlen = sizeof(eal_all_mem_zone_ret_t) +
+                    all_eal_mem_zone_ret->zone_num * sizeof(eal_mem_zone_ret_t);
+            break;
+
+        case SOCKOPT_GET_EAL_MEM_RING:
+            size = sizeof(eal_all_mem_ring_ret_t) +
+                    MAX_MEMZONE_NUM * sizeof(eal_mem_ring_ret_t);
+            all_eal_mem_ring_ret = rte_zmalloc("mem_ring", size, 0);
+            if (unlikely(!all_eal_mem_ring_ret)) {
+                ret = EDPVS_NOMEM;
+                return ret;
+            }
+            if (dp_vs_get_eal_mem_ring(all_eal_mem_ring_ret) < 0) {
+                ret = EDPVS_DPDKAPIFAIL;
+                rte_free(all_eal_mem_ring_ret);
+                all_eal_mem_ring_ret = NULL;
+                return ret;
+            }
+            *out = all_eal_mem_ring_ret;
+            *outlen = sizeof(eal_all_mem_ring_ret_t) +
+                    all_eal_mem_ring_ret->ring_num * sizeof(eal_mem_ring_ret_t);
+            break;
+
+        case SOCKOPT_GET_EAL_MEM_POOL:
+            size = sizeof(eal_all_mem_pool_ret_t) +
+                    MAX_MEMZONE_NUM * sizeof(eal_mem_pool_ret_t);
+            all_eal_mem_pool_ret = rte_zmalloc("mem_pool", size, 0);
+            if (unlikely(!all_eal_mem_pool_ret)) {
+                ret = EDPVS_NOMEM;
+                return ret;
+            }
+            if (dp_vs_get_eal_mem_pool(all_eal_mem_pool_ret) < 0) {
+                ret = EDPVS_DPDKAPIFAIL;
+                rte_free(all_eal_mem_pool_ret);
+                all_eal_mem_pool_ret = NULL;
+                return ret;
+            }
+            *out = all_eal_mem_pool_ret;
+            *outlen = sizeof(eal_all_mem_pool_ret_t) +
+                    all_eal_mem_pool_ret->mempool_num * sizeof(eal_mem_pool_ret_t);
+            break;
+
+        default:
+            ret = EDPVS_INVAL;
+            break;
+    }
+
+    return ret;
+}
+
+static struct dpvs_sockopts eal_mem_sockopts = {
+    .version        = SOCKOPT_VERSION,
+    .set_opt_min    = SOCKOPT_SET_EAL_MEM_NONE,
+    .set_opt_max    = SOCKOPT_SET_EAL_MEM_NONE,
+    .set            = NULL,
+    .get_opt_min    = SOCKOPT_GET_EAL_MEM_SEG,
+    .get_opt_max    = SOCKOPT_GET_EAL_MEM_POOL,
+    .get            = dp_vs_eal_mem_get,
+};
+
+int eal_mem_init(void)
+{
+    return sockopt_register(&eal_mem_sockopts);
+}
+
+int eal_mem_term(void)
+{
+    return sockopt_unregister(&eal_mem_sockopts);
+}
+

--- a/src/main.c
+++ b/src/main.c
@@ -36,6 +36,7 @@
 #include "sys_time.h"
 #include "route6.h"
 #include "iftraf.h"
+#include "eal_mem.h"
 #include "scheduler.h"
 
 #define DPVS    "dpvs"
@@ -254,7 +255,10 @@ int main(int argc, char *argv[])
 
     if ((err = iftraf_init()) != EDPVS_OK)
         rte_exit(EXIT_FAILURE, "Fail to init stats: %s\n", dpvs_strerror(err));
-    
+
+    if ((err = eal_mem_init()) != EDPVS_OK)
+        rte_exit(EXIT_FAILURE, "Fail to init eal mem: %s\n", dpvs_strerror(err));
+
     /* config and start all available dpdk ports */
     nports = dpvs_rte_eth_dev_count();
     for (pid = 0; pid < nports; pid++) {
@@ -291,6 +295,10 @@ int main(int argc, char *argv[])
 
 end:
     dpvs_state_set(DPVS_STATE_FINISH);
+    if ((err = eal_mem_term()) !=0 )
+        rte_exit(EXIT_FAILURE, "Fail to term eal mem: %s\n",
+                dpvs_strerror(err));
+
     if ((err = iftraf_term()) !=0 )
         rte_exit(EXIT_FAILURE, "Fail to term iftraf: %s\n",
                 dpvs_strerror(err));

--- a/tools/dpip/Makefile
+++ b/tools/dpip/Makefile
@@ -33,7 +33,7 @@ DEFS = -D DPVS_MAX_LCORE=64
 CFLAGS += $(DEFS)
 
 OBJS = dpip.o utils.o route.o addr.o neigh.o link.o vlan.o \
-	   qsch.o cls.o tunnel.o ipset.o ipv6.o iftraf.o ../../src/common.o \
+	   qsch.o cls.o tunnel.o ipset.o ipv6.o iftraf.o eal_mem.o ../../src/common.o \
 	   ../keepalived/keepalived/check/sockopt.o
 
 all: $(TARGET)

--- a/tools/dpip/dpip.c
+++ b/tools/dpip/dpip.c
@@ -34,7 +34,7 @@ static void usage(void)
         "    "DPIP_NAME" [OPTIONS] OBJECT { COMMAND | help }\n"
         "Parameters:\n"
         "    OBJECT  := { link | addr | route | neigh | vlan | tunnel |\n"
-        "                 qsch | cls | ipv6 | iftraf }\n"
+        "                 qsch | cls | ipv6 | iftraf | eal-mem }\n"
         "    COMMAND := { add | del | change | replace | show | flush | enable | disable }\n"
         "Options:\n"
         "    -v, --verbose\n"

--- a/tools/dpip/eal_mem.c
+++ b/tools/dpip/eal_mem.c
@@ -1,0 +1,196 @@
+/*
+ * DPVS is a software load balancer (Virtual Server) based on DPDK.
+ *
+ * Copyright (C) 2017 iQIYI (www.iqiyi.com).
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "conf/common.h"
+#include "dpip.h"
+#include "conf/eal_mem.h"
+#include "sockopt.h"
+
+static void eal_mem_help(void)
+{
+    fprintf(stderr,
+            "Usage:\n"
+            "    dpip eal-mem show [seg | ring | zone | pool] \n"
+           );
+}
+
+static void list_eal_mem_seg_info(eal_all_mem_seg_ret_t *all_eal_mem_seg_ret)
+{
+    eal_mem_seg_ret_t *seg_ret = NULL;
+    int i = 0;
+
+    printf("%-10s %16s %16s %20s %20s %10s %10s %20s\n",
+            "socket_id", "phys_addr(Hex)", "virt_addr(Hex)", "len(KB)",
+            "hugepage_size(KB)","nchannel", "nrank", "free_len(KB)");
+
+    for (i = 0; i < all_eal_mem_seg_ret->seg_num; i++) {
+        seg_ret = &all_eal_mem_seg_ret->seg_info[i];
+        printf("%-10d %16lx %16lx %20lu %20lu %10u %10u %20lu\n",
+                seg_ret->socket_id, seg_ret->phys_addr, seg_ret->virt_addr,
+                seg_ret->len / 1024, seg_ret->hugepage_sz / 1024,
+                seg_ret->nchannel, seg_ret->nrank,
+                seg_ret->free_seg_len / 1024);
+    }
+}
+
+static void list_eal_mem_pool_info(eal_all_mem_pool_ret_t *all_eal_mem_pool_ret)
+{
+    eal_mem_pool_ret_t *mempool_ret = NULL;
+    int i = 0;
+
+    printf("%-20s %10s %10s %11s %12s %17s %10s %10s %10s\n",
+            "pool_name", "flags", "elt_size", "header_size",
+            "trailer_size", "private_data_size", "size", "used", "Mem(MB)");
+
+    for (i = 0; i < all_eal_mem_pool_ret->mempool_num; i++) {
+        mempool_ret = &all_eal_mem_pool_ret->mempool_info[i];
+        printf("%-20s %10u %10u %11u %12u %17u %10u %10u %10llu\n",
+                mempool_ret->name, mempool_ret->flags, mempool_ret->elt_size,
+                mempool_ret->header_size, mempool_ret->trailer_size,
+                mempool_ret->private_data_size, mempool_ret->size,
+                mempool_ret->size - mempool_ret->count,
+                1ULL * (mempool_ret->elt_size + mempool_ret->header_size +
+                mempool_ret->trailer_size) * mempool_ret->size / 1024 / 1024);
+    }
+}
+
+static void list_eal_mem_zone_info(eal_all_mem_zone_ret_t *all_eal_mem_zone_ret)
+{
+    eal_mem_zone_ret_t *zone_ret = NULL;
+    int i = 0;
+
+    printf("%-8s %32s %16s %16s %20s %20s %10s\n", "zone_id",
+            "zone_name", "phys_addr(Hex)", "virt_addr(Hex)", "len(KB)", "hugepage_size(KB)",
+            "socket_id");
+
+    for (i = 0; i < all_eal_mem_zone_ret->zone_num; i++) {
+        zone_ret = &all_eal_mem_zone_ret->zone_info[i];
+        printf("%-8d %32s %16lx %16lx %20lu %20lu %10d\n", i,
+                zone_ret->name, zone_ret->phys_addr, zone_ret->virt_addr,
+                zone_ret->len / 1024, zone_ret->hugepage_sz / 1024, zone_ret->socket_id);
+    }
+}
+
+static void list_eal_mem_ring_info(eal_all_mem_ring_ret_t *all_eal_mem_ring_ret)
+{
+    eal_mem_ring_ret_t *ring_ret = NULL;
+    int i = 0;
+
+    printf("%-20s %10s %10s %10s %10s %10s %10s %10s %10s\n",
+            "ring_name", "flags", "size", "cons_tail", "cons_head",
+            "prod_tail", "prod_head", "used", "avail");
+
+    for (i = 0; i < all_eal_mem_ring_ret->ring_num; i++) {
+        ring_ret = &all_eal_mem_ring_ret->ring_info[i];
+        printf("%-20s %10d %10u %10u %10u %10u %10u %10u %10u\n",
+                ring_ret->name, ring_ret->flags, ring_ret->size,
+                ring_ret->cons_tail, ring_ret->cons_head, ring_ret->prod_tail,
+                ring_ret->prod_head, ring_ret->used, ring_ret->avail);
+    }
+}
+
+static int eal_mem_parse_cmd_type(struct dpip_conf *conf,
+                            sockoptid_t *cmd_type)
+{
+    if (0 == conf->argc) {
+        *cmd_type = SOCKOPT_GET_EAL_MEM_SEG;
+        return 0;
+    }
+    else if (conf->argc > 1) {
+        fprintf(stderr, "too many arguments!\n");
+        eal_mem_help();
+        return -1;
+    }
+
+    if (0 == strcmp(conf->argv[0], "seg")) {
+        *cmd_type = SOCKOPT_GET_EAL_MEM_SEG;
+    }
+    else if (0 == strcmp(conf->argv[0], "zone")) {
+        *cmd_type = SOCKOPT_GET_EAL_MEM_ZONE;
+    }
+    else if (0 == strcmp(conf->argv[0], "ring")) {
+        *cmd_type = SOCKOPT_GET_EAL_MEM_RING;
+    }
+    else if (0 == strcmp(conf->argv[0], "pool")) {
+        *cmd_type = SOCKOPT_GET_EAL_MEM_POOL;
+    }
+    else {
+        fprintf(stderr, "eal mem parameter invalid!\n");
+        eal_mem_help();
+        return -1;
+    }
+
+    return 0;
+}
+
+static int eal_mem_do_cmd(struct dpip_obj *obj, dpip_cmd_t cmd,
+                       struct dpip_conf *conf)
+{
+    size_t size = 0;
+    void *reply = NULL;
+    sockoptid_t cmd_type = 0;
+    int err;
+
+    if (eal_mem_parse_cmd_type(conf, &cmd_type) != 0)
+        return EDPVS_INVAL;
+
+    err = dpvs_getsockopt(cmd_type, NULL, 0, (void **)&reply, &size);
+    if (ESOCKOPT_OK != err) {
+        return err;
+    }
+
+    switch (cmd_type) {
+        case SOCKOPT_GET_EAL_MEM_SEG:
+            list_eal_mem_seg_info((eal_all_mem_seg_ret_t *)reply);
+            break;
+
+        case SOCKOPT_GET_EAL_MEM_POOL:
+            list_eal_mem_pool_info((eal_all_mem_pool_ret_t *)reply);
+            break;
+
+        case SOCKOPT_GET_EAL_MEM_ZONE:
+            list_eal_mem_zone_info((eal_all_mem_zone_ret_t *)reply);
+            break;
+
+        case SOCKOPT_GET_EAL_MEM_RING:
+            list_eal_mem_ring_info((eal_all_mem_ring_ret_t *)reply);
+            break;
+    }
+    dpvs_sockopt_msg_free(reply);
+
+    return EDPVS_OK;
+}
+
+struct dpip_obj dpip_eal_mem = {
+    .name   = "eal-mem",
+    .help   = eal_mem_help,
+    .do_cmd = eal_mem_do_cmd,
+};
+
+static void __init eal_mem_init(void)
+{
+    dpip_register_obj(&dpip_eal_mem);
+}
+
+static void __exit eal_mem_exit(void)
+{
+    dpip_unregister_obj(&dpip_eal_mem);
+}
+


### PR DESCRIPTION
Currently there is no effective tool to check dpdk memory usage; the commit is used to display dpdk memory usage;
The method of use is as follows：
$dpip eal-mem help
Usage:
    dpip eal-mem show [seg | ring | zone | pool]