### PR TITLE
conhash: use weight ratio to reduce virtual node num in rbtree

### DIFF
--- a/include/ipvs/sched.h
+++ b/include/ipvs/sched.h
@@ -50,6 +50,8 @@ int dp_vs_bind_scheduler(struct dp_vs_service *svc,
 
 int dp_vs_unbind_scheduler(struct dp_vs_service *svc);
 
+int dp_vs_gcd_weight(struct dp_vs_service *svc);
+
 void dp_vs_scheduler_put(struct dp_vs_scheduler *scheduler);
 
 int register_dp_vs_scheduler(struct dp_vs_scheduler *scheduler);

--- a/src/ipvs/ip_vs_conhash.c
+++ b/src/ipvs/ip_vs_conhash.c
@@ -25,10 +25,6 @@
 
 struct conhash_node {
     struct list_head    list;
-    uint16_t            weight_ratio;
-    int                 af;         /* address family */
-    union inet_addr     addr;       /* IP address of the server */
-    uint16_t            port;       /* port number of the server */
     struct node_s       node;       /* node in libconhash */
 };
 
@@ -158,8 +154,8 @@ static int dp_vs_conhash_add_dest(struct dp_vs_service *svc,
         struct dp_vs_dest *dest)
 {
     int ret;
-    char str[40];
-    uint32_t addr_fold;
+    char iden[64];
+    char addr[INET6_ADDRSTRLEN];
     int16_t weight = 0;
     struct node_s *p_node;
     struct conhash_node *p_conhash_node;
@@ -184,17 +180,13 @@ static int dp_vs_conhash_add_dest(struct dp_vs_service *svc,
     }
 
     INIT_LIST_HEAD(&(p_conhash_node->list));
-    p_conhash_node->af = dest->af;
-    p_conhash_node->addr = dest->addr;
-    p_conhash_node->port = dest->port;
-    p_conhash_node->weight_ratio = weight / weight_gcd;
 
     // add node to conhash
     p_node = &(p_conhash_node->node);
-    addr_fold = inet_addr_fold(dest->af, &dest->addr);
-    snprintf(str, sizeof(str), "%u%d", addr_fold, dest->port);
+    inet_ntop(dest->af, &dest->addr, addr, sizeof(addr));
+    snprintf(iden, sizeof(iden), "%s%d", addr, dest->port);
+    conhash_set_node(p_node, iden, weight / weight_gcd * REPLICA);
 
-    conhash_set_node(p_node, str, p_conhash_node->weight_ratio * REPLICA);
     ret = conhash_add_node(p_sched_data->conhash, p_node);
     if (ret < 0) {
         RTE_LOG(ERR, SERVICE, "%s: conhash_add_node failed\n", __func__);
@@ -223,9 +215,7 @@ static int dp_vs_conhash_del_dest(struct dp_vs_service *svc,
     p_sched_data = (struct conhash_sched_data *)(svc->sched_data);
 
     list_for_each_entry(p_conhash_node, &(p_sched_data->nodes), list) {
-        if (p_conhash_node->af == dest->af &&
-                inet_addr_equal(dest->af, &p_conhash_node->addr, &dest->addr) &&
-                p_conhash_node->port == dest->port) {
+        if (p_conhash_node->node.data == dest) {
             p_node = &(p_conhash_node->node);
             ret = conhash_del_node(p_sched_data->conhash, p_node);
             if (ret < 0) {
@@ -244,8 +234,8 @@ static int dp_vs_conhash_edit_dest(struct dp_vs_service *svc,
         struct dp_vs_dest *dest)
 {
     int ret;
-    char str[40];
-    uint32_t addr_fold;
+    char iden[64];
+    char addr[INET6_ADDRSTRLEN];
     int16_t weight;
     struct node_s *p_node;
     struct conhash_node *p_conhash_node;
@@ -258,10 +248,8 @@ static int dp_vs_conhash_edit_dest(struct dp_vs_service *svc,
 
     // find node by addr and port
     list_for_each_entry(p_conhash_node, &(p_sched_data->nodes), list) {
-        if (p_conhash_node->af == dest->af &&
-                inet_addr_equal(dest->af, &p_conhash_node->addr, &dest->addr) &&
-                p_conhash_node->port == dest->port) {
-            if (p_conhash_node->weight_ratio == weight / weight_gcd)
+        if (p_conhash_node->node.data == dest) {
+            if (p_conhash_node->node.replicas == weight / weight_gcd * REPLICA)
                 return EDPVS_OK;
 
             // del from conhash
@@ -273,10 +261,9 @@ static int dp_vs_conhash_edit_dest(struct dp_vs_service *svc,
             }
 
             // adjust weight
-            p_conhash_node->weight_ratio = weight / weight_gcd;
-            addr_fold = inet_addr_fold(dest->af, &dest->addr);
-            snprintf(str, sizeof(str), "%u%d", addr_fold, dest->port);
-            conhash_set_node(p_node, str, p_conhash_node->weight_ratio * REPLICA);
+            inet_ntop(dest->af, &dest->addr, addr, sizeof(addr));
+            snprintf(iden, sizeof(iden), "%s%d", addr, dest->port);
+            conhash_set_node(p_node, iden, weight / weight_gcd * REPLICA);
 
             // add to conhash again
             ret = conhash_add_node(p_sched_data->conhash, p_node);

--- a/src/ipvs/ip_vs_sched.c
+++ b/src/ipvs/ip_vs_sched.c
@@ -87,6 +87,38 @@ int dp_vs_unbind_scheduler(struct dp_vs_service *svc)
 }
 
 /*
+ *    Get the gcd of server weights
+ */
+static int gcd(int a, int b)
+{
+    int c;
+
+    while ((c = a % b)) {
+        a = b;
+        b = c;
+    }
+    return b;
+}
+
+int dp_vs_gcd_weight(struct dp_vs_service *svc)
+{
+    struct dp_vs_dest *dest;
+    int weight;
+    int g = 0;
+
+    list_for_each_entry(dest, &svc->dests, n_list) {
+        weight = rte_atomic16_read(&dest->weight);
+        if (weight > 0) {
+            if (g > 0)
+                g = gcd(weight, g);
+            else
+                g = weight;
+        }
+    }
+    return g ? g : 1;
+}
+
+/*
  *  Lookup scheduler and try to load it if it doesn't exist
  */
 struct dp_vs_scheduler *dp_vs_scheduler_get(const char *sched_name)


### PR DESCRIPTION
the memory will be a big problem with the conhash scheduling for vs when large count of vs and rs configured per lcore.