### PR TITLE
scheduler: a performance optimization

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -20,6 +20,9 @@
 #include "conf/common.h"
 #include "scheduler.h"
 
+RTE_DEFINE_PER_LCORE(uint32_t, dp_vs_job_loop_tick);
+#define this_job_loop_tick (RTE_PER_LCORE(dp_vs_job_loop_tick))
+
 /* Note: lockless, lcore_job can only be register on initialization stage and
  *       unregistered on cleanup stage.
  */
@@ -160,7 +163,7 @@ static int dpvs_job_loop(void *arg)
     struct dpvs_lcore_job *job;
     lcoreid_t cid = rte_lcore_id();
     dpvs_lcore_role_t role = g_lcore_role[cid];
-    static uint32_t dpvs_job_loop_tick[DPVS_MAX_LCORE] = { 0 };
+    this_job_loop_tick = 0;
 #ifdef CONFIG_RECORD_BIG_LOOP
     char buf[512];
     uint32_t loop_time, thres_time;
@@ -190,7 +193,7 @@ static int dpvs_job_loop(void *arg)
 #ifdef CONFIG_RECORD_BIG_LOOP
         loop_start = rte_get_timer_cycles();
 #endif
-        ++dpvs_job_loop_tick[cid];
+        ++this_job_loop_tick;
         netif_update_worker_loop_cnt();
 
         /* do normal job */
@@ -200,7 +203,7 @@ static int dpvs_job_loop(void *arg)
 
         /* do slow job */
         list_for_each_entry(job, &dpvs_lcore_jobs[role][LCORE_JOB_SLOW], list) {
-            if (dpvs_job_loop_tick[cid] % job->skip_loops == 0) {
+            if (this_job_loop_tick % job->skip_loops == 0) {
                 do_lcore_job(job);
             }
         }


### PR DESCRIPTION
Use per lcore variable instead of a global array. The origin global array has cache false sharing issue,
and it is in critical datapath. Use per lcore variable to fix this issue.
According to my personal simple testing, it can improve about 8% pps for syn flood traffic.