### PR TITLE
ipvs: no need to zero the bytes of the newly allocated dpvs connection.

### DIFF
--- a/src/ipvs/ip_vs_conn.c
+++ b/src/ipvs/ip_vs_conn.c
@@ -98,7 +98,6 @@ static struct dp_vs_conn *dp_vs_conn_alloc(enum dpvs_fwd_mode fwdmode,
         return NULL;
     }
 
-    memset(conn, 0, sizeof(struct dp_vs_conn));
     conn->connpool = this_conn_cache;
     this_conn_count++;
 


### PR DESCRIPTION
- TCP CPS can be increased by 10% for the single core with TCP flood traffic
  sent by hping3.