### PR TITLE
KNI: Add worker type kni

### DIFF
--- a/conf/dpvs.conf.sample
+++ b/conf/dpvs.conf.sample
@@ -212,6 +212,17 @@ worker_defs {
         }
     }
 
+    !<init> worker   cpu9 {
+    !    type        kni
+    !    cpu_id      9
+    !    port        dpdk0 {
+    !        tx_queue_ids     8
+    !    }
+    !    port        dpdk1 {
+    !        tx_queue_ids     8
+    !    }
+    !}
+
 }
 
 ! timer config

--- a/include/conf/netif.h
+++ b/include/conf/netif.h
@@ -57,6 +57,7 @@ enum {
 typedef struct netif_lcore_mask_get
 {
     lcoreid_t master_lcore_id;
+    lcoreid_t kni_lcore_id;
     uint8_t slave_lcore_num;
     uint8_t isol_rx_lcore_num;
     uint64_t slave_lcore_mask;

--- a/include/global_data.h
+++ b/include/global_data.h
@@ -26,6 +26,7 @@ typedef enum dpvs_lcore_role_type {
     LCORE_ROLE_MASTER,
     LCORE_ROLE_FWD_WORKER,
     LCORE_ROLE_ISOLRX_WORKER,
+    LCORE_ROLE_KNI_WORKER,
     LCORE_ROLE_MAX
 } dpvs_lcore_role_t;
 

--- a/include/netif.h
+++ b/include/netif.h
@@ -21,6 +21,7 @@
 #include "list.h"
 #include "dpdk.h"
 #include "inetaddr.h"
+#include "global_data.h"
 #include "timer.h"
 #include "tc/tc.h"
 
@@ -104,6 +105,7 @@ struct netif_port_conf
 struct netif_lcore_conf
 {
     lcoreid_t id;
+    enum dpvs_lcore_role_type type;
     /* nic number of this lcore to process */
     int nports;
     /* port list of this lcore to process */
@@ -167,6 +169,7 @@ struct netif_kni {
     struct ether_addr addr;
     struct dpvs_timer kni_rtnl_timer;
     int kni_rtnl_fd;
+    struct rte_ring *rx_ring;
 } __rte_cache_aligned;
 
 union netif_bond {
@@ -264,7 +267,7 @@ void netif_update_worker_loop_cnt(void);
 int netif_register_master_xmit_msg(void);
 int netif_lcore_conf_set(int lcores, const struct netif_lcore_conf *lconf);
 bool is_lcore_id_valid(lcoreid_t cid);
-bool netif_lcore_is_idle(lcoreid_t cid);
+bool netif_lcore_is_fwd_worker(lcoreid_t cid);
 void lcore_process_packets(struct netif_queue_conf *qconf, struct rte_mbuf **mbufs,
                            lcoreid_t cid, uint16_t count, bool pkts_from_ring);
 

--- a/src/ipset.c
+++ b/src/ipset.c
@@ -310,8 +310,8 @@ static int ipset_lcore_init(void *arg)
     if (!rte_lcore_is_enabled(rte_lcore_id()))
         return EDPVS_DISABLED;
 
-    if (netif_lcore_is_idle(rte_lcore_id()))
-        return EDPVS_IDLE;
+    if (!netif_lcore_is_fwd_worker(rte_lcore_id()))
+        return EDPVS_NOTSUPP;
 
     for (i = 0; i < IPSET_TAB_SIZE; i++)
         INIT_LIST_HEAD(&this_ipset_table_lcore[i]);

--- a/src/ipvs/ip_vs_conn.c
+++ b/src/ipvs/ip_vs_conn.c
@@ -1172,7 +1172,7 @@ static int conn_init_lcore(void *arg)
     if (!rte_lcore_is_enabled(rte_lcore_id()))
         return EDPVS_DISABLED;
 
-    if (netif_lcore_is_idle(rte_lcore_id()))
+    if (!netif_lcore_is_fwd_worker(rte_lcore_id()))
         return EDPVS_IDLE;
 
     this_conn_tbl = rte_malloc(NULL,

--- a/src/ipvs/ip_vs_redirect.c
+++ b/src/ipvs/ip_vs_redirect.c
@@ -355,13 +355,12 @@ static int dp_vs_redirect_ring_create(void)
     socket_id = rte_socket_id();
 
     for (cid = 0; cid < DPVS_MAX_LCORE; cid++) {
-        if (cid == rte_get_master_lcore() || netif_lcore_is_idle(cid)) {
+        if (!netif_lcore_is_fwd_worker(cid)) {
             continue;
         }
 
         for (peer_cid = 0; peer_cid < DPVS_MAX_LCORE; peer_cid++) {
-            if (netif_lcore_is_idle(peer_cid)
-                || peer_cid == rte_get_master_lcore()
+            if (!netif_lcore_is_fwd_worker(peer_cid)
                 || cid == peer_cid) {
                 continue;
             }

--- a/src/netif.c
+++ b/src/netif.c
@@ -144,6 +144,8 @@ static struct list_head port_ntab[NETIF_PORT_TABLE_BUCKETS]; /* hashed by name *
 #define NETIF_CTRL_BUFFER_LEN     4096
 
 lcoreid_t g_master_lcore_id;
+/* By default g_kni_lcore_id is 0 and it indicates KNI core is not configured. */
+lcoreid_t g_kni_lcore_id = 0;
 static uint8_t g_slave_lcore_num;
 static uint8_t g_isol_rx_lcore_num;
 static uint64_t g_slave_lcore_mask;
@@ -155,6 +157,7 @@ bool is_lcore_id_valid(lcoreid_t cid)
         return false;
 
     return ((cid == rte_get_master_lcore()) ||
+            (cid == g_kni_lcore_id) ||
             (g_slave_lcore_mask & (1L << cid)) ||
             (g_isol_rx_lcore_mask & (1L << cid)));
 }
@@ -644,7 +647,8 @@ static void worker_type_handler(vector_t tokens)
             struct worker_conf_stream, worker_list_node);
 
     assert(str);
-    if (!strcmp(str, "master") || !strcmp(str, "slave")) {
+    if (!strcmp(str, "master") || !strcmp(str, "slave")
+        || !strcmp(str, "kni")) {
         RTE_LOG(INFO, NETIF, "%s:type = %s\n", current_worker->name, str);
         strncpy(current_worker->type, str, sizeof(current_worker->type));
     } else {
@@ -672,6 +676,9 @@ static void cpu_id_handler(vector_t tokens)
         cpu_id = atoi(str);
         RTE_LOG(INFO, NETIF, "%s:cpu_id = %d\n", current_worker->name, cpu_id);
         current_worker->cpu_id = cpu_id;
+
+        if (!strcmp(current_worker->type, "kni"))
+            g_kni_lcore_id = cpu_id;
     }
 
     FREE_PTR(str);
@@ -692,8 +699,11 @@ static void worker_port_handler(vector_t tokens)
         return;
     }
 
-    for (ii = 0; ii < NETIF_MAX_QUEUES; ii++)
+    for (ii = 0; ii < NETIF_MAX_QUEUES; ii++) {
+        queue_cfg->tx_queues[ii] = NETIF_MAX_QUEUES;
+        queue_cfg->rx_queues[ii] = NETIF_MAX_QUEUES;
         queue_cfg->isol_rxq_lcore_ids[ii] = NETIF_LCORE_ID_INVALID;
+    }
     queue_cfg->isol_rxq_ring_sz = NETIF_ISOL_RXQ_RING_SZ_DEF;
 
     str = VECTOR_SLOT(tokens, 1);
@@ -1095,20 +1105,25 @@ static void isol_rxq_del(struct rx_partner *isol_rxq, bool force);
 static void config_lcores(struct list_head *worker_list)
 {
     int ii, tk;
-    int cpu_id_min, cpu_left;
+    int cpu_id_min, cpu_left, cpu_cnt;
     lcoreid_t id = 0;
     portid_t pid;
     struct netif_port *port;
     struct queue_conf_stream *queue;
-    struct worker_conf_stream *worker, *worker_min;
+    struct worker_conf_stream *worker, *worker_next, *worker_min;
 
-    cpu_left = list_elems(worker_list);
-    list_for_each_entry(worker, worker_list, worker_list_node) {
-        if (strcmp(worker->type, "slave")) {
+    memset(lcore_conf, 0, sizeof(lcore_conf));
+
+    cpu_cnt = cpu_left = list_elems(worker_list);
+    list_for_each_entry_safe(worker, worker_next, worker_list, worker_list_node) {
+        if (!strcmp(worker->type, "master")) {
             list_move_tail(&worker->worker_list_node, worker_list);
             cpu_left--;
         }
+        if (--cpu_cnt == 0)
+            break;
     }
+
     while (cpu_left > 0) {
         cpu_id_min = DPVS_MAX_LCORE;
         worker_min = NULL;
@@ -1126,6 +1141,13 @@ static void config_lcores(struct list_head *worker_list)
 
         tk = 0;
         lcore_conf[id].id = worker_min->cpu_id;
+        if (!strncmp(worker_min->type, "slave", sizeof("slave")))
+            lcore_conf[id].type = LCORE_ROLE_FWD_WORKER;
+        else if (!strncmp(worker_min->type, "kni", sizeof("kni")))
+            lcore_conf[id].type = LCORE_ROLE_KNI_WORKER;
+        else
+            lcore_conf[id].type = LCORE_ROLE_IDLE;
+
         list_for_each_entry_reverse(queue, &worker_min->port_list, queue_list_node) {
             port = netif_port_get_by_name(queue->port_name);
             if (port)
@@ -1134,7 +1156,8 @@ static void config_lcores(struct list_head *worker_list)
                 pid = NETIF_PORT_ID_INVALID;
             lcore_conf[id].pqs[tk].id = pid;
 
-            for (ii = 0; queue->rx_queues[ii] != NETIF_MAX_QUEUES; ii++) {
+            for (ii = 0; queue->rx_queues[ii] != NETIF_MAX_QUEUES && ii < NETIF_MAX_QUEUES;
+                 ii++) {
                 lcore_conf[id].pqs[tk].rxqs[ii].id = queue->rx_queues[ii];
                 if (queue->isol_rxq_lcore_ids[ii] != NETIF_LCORE_ID_INVALID) {
                     if (isol_rxq_add(queue->isol_rxq_lcore_ids[ii],
@@ -1154,7 +1177,8 @@ static void config_lcores(struct list_head *worker_list)
             }
             lcore_conf[id].pqs[tk].nrxq = ii;
 
-            for (ii = 0; queue->tx_queues[ii] != NETIF_MAX_QUEUES; ii++)
+            for (ii = 0; queue->tx_queues[ii] != NETIF_MAX_QUEUES && ii < NETIF_MAX_QUEUES;
+                 ii++)
                 lcore_conf[id].pqs[tk].txqs[ii].id = queue->tx_queues[ii];
             lcore_conf[id].pqs[tk].ntxq = ii;
             tk++;
@@ -1170,13 +1194,6 @@ static void config_lcores(struct list_head *worker_list)
 /* fast searching tables */
 lcoreid_t lcore2index[DPVS_MAX_LCORE+1];
 portid_t port2index[DPVS_MAX_LCORE][NETIF_MAX_PORTS];
-
-bool netif_lcore_is_idle(lcoreid_t cid)
-{
-    if (cid > DPVS_MAX_LCORE)
-        return true;
-    return (lcore_conf[lcore2index[cid]].nports == 0) ? true : false;
-}
 
 static void lcore_index_init(void)
 {
@@ -1233,8 +1250,12 @@ void netif_get_slave_lcores(uint8_t *nb, uint64_t *mask)
     uint8_t slave_lcore_nb = 0;
 
     while (lcore_conf[i].nports > 0) {
-        slave_lcore_nb++;
-        slave_lcore_mask |= (1L << lcore_conf[i].id);
+        /* LCORE_ROLE_KNI_WORKER should be excluded,
+         * as ports is configured for KNI core. */
+        if (lcore_conf[i].type == LCORE_ROLE_FWD_WORKER) {
+            slave_lcore_nb++;
+            slave_lcore_mask |= (1L << lcore_conf[i].id);
+        }
         i++;
     }
 
@@ -1298,7 +1319,7 @@ static void lcore_role_init(void)
     while (lcore_conf[i].nports > 0) {
         cid = lcore_conf[i].id;
         assert(g_lcore_role[cid] == LCORE_ROLE_IDLE);
-        g_lcore_role[cid] = LCORE_ROLE_FWD_WORKER;
+        g_lcore_role[cid] = lcore_conf[i].type;
         i++;
     }
 
@@ -1407,6 +1428,8 @@ static int check_lcore_conf(int lcores, const struct netif_lcore_conf *lcore_con
             for (k = 0; k < lcore_conf[i].pqs[j].nrxq; k++) {
                 qid = lcore_conf[i].pqs[j].rxqs[k].id;
                 if (LCONFCHK_MARK == mark.pqs[pid].rxqs[qid].id) {
+                    RTE_LOG(ERR, NETIF, "rx qid: %d for cid: %d is already used.",
+                            qid, lcore_conf[i].id);
                     return LCONFCHK_REPEATED_RX_QUEUE_ID;
                 } else
                     mark.pqs[pid].rxqs[qid].id = LCONFCHK_MARK;
@@ -1414,6 +1437,8 @@ static int check_lcore_conf(int lcores, const struct netif_lcore_conf *lcore_con
             for (k = 0; k <lcore_conf[i].pqs[j].ntxq; k++) {
                 qid = lcore_conf[i].pqs[j].txqs[k].id;
                 if (LCONFCHK_MARK == mark.pqs[pid].txqs[qid].id) {
+                    RTE_LOG(ERR, NETIF, "tx qid: %d for cid: %d is already used.",
+                            qid, lcore_conf[i].id);
                     return LCONFCHK_REPEATED_TX_QUEUE_ID;
                 } else
                     mark.pqs[pid].txqs[qid].id = LCONFCHK_MARK;
@@ -1577,6 +1602,22 @@ inline static bool is_isol_rxq_lcore(lcoreid_t cid)
     assert(cid < DPVS_MAX_LCORE);
 
     return !list_empty(&isol_rxq_tab[cid]);
+}
+
+inline static bool is_kni_lcore(lcoreid_t cid)
+{
+    assert(cid < DPVS_MAX_LCORE);
+
+    return g_kni_lcore_id == cid;
+}
+
+bool netif_lcore_is_fwd_worker(lcoreid_t cid)
+{
+    if (cid > DPVS_MAX_LCORE)
+        return false;
+
+    return (lcore_conf[lcore2index[cid]].type  ==
+            LCORE_ROLE_FWD_WORKER) ? true : false;
 }
 
 static inline uint16_t netif_rx_burst(portid_t pid, struct netif_queue_conf *qconf)
@@ -1952,8 +1993,8 @@ static inline lcoreid_t get_master_xmit_lcore(void)
     static int i = 0;
     lcoreid_t cid;
 
-    if (lcore_conf[i].nports > 0) {
-        cid = lcore_conf[i].id;
+    cid = lcore_conf[i].id;
+    if (netif_lcore_is_fwd_worker(cid)) {
         i++;
     } else {
         cid = lcore_conf[0].id;
@@ -2100,6 +2141,7 @@ int netif_hard_xmit(struct rte_mbuf *mbuf, struct netif_port *dev)
     //RTE_LOG(DEBUG, NETIF, "tx-queue hash(%x) = %d\n", ((uint32_t)mbuf->buf_physaddr) >> 8, qindex);
     txq = &lcore_conf[lcore2index[cid]].pqs[port2index[cid][pid]].txqs[qindex];
 
+    /* Date plane traffic should be buffered for NETIF_MAX_PKT_BURST pkts to transmit. */
     if (unlikely(txq->len == NETIF_MAX_PKT_BURST)) {
         netif_tx_burst(cid, pid, qindex);
         txq->len = 0;
@@ -2108,6 +2150,13 @@ int netif_hard_xmit(struct rte_mbuf *mbuf, struct netif_port *dev)
     lcore_stats[cid].obytes += mbuf->pkt_len;
     txq->mbufs[txq->len] = mbuf;
     txq->len++;
+
+    /* kni lcore needs to send packets ASAP, otherwise packets will be buffered for a while. */
+    if (unlikely(is_kni_lcore(cid))) {
+        netif_tx_burst(cid, pid, qindex);
+        txq->len = 0;
+    }
+
     return EDPVS_OK;
 }
 
@@ -2454,6 +2503,7 @@ static void lcore_job_timer_manage(void *args)
 }
 
 static void kni_process_on_master(void *dummy);
+static void kni_lcore_loop(void *dummy);
 
 #define NETIF_JOB_MAX   6
 struct dpvs_lcore_job_array {
@@ -2524,11 +2574,19 @@ static void netif_lcore_init(void)
     netif_jobs[4].job.data = NULL;
     netif_jobs[4].job.type = LCORE_JOB_LOOP;
 
-    netif_jobs[5].role = LCORE_ROLE_MASTER;
-    snprintf(netif_jobs[5].job.name, sizeof(netif_jobs[5].job.name) - 1, "%s", "kni_master_proc");
-    netif_jobs[5].job.func = kni_process_on_master;
-    netif_jobs[5].job.data = NULL;
-    netif_jobs[5].job.type = LCORE_JOB_LOOP;
+    if (g_kni_lcore_id == 0) {
+        netif_jobs[5].role = LCORE_ROLE_MASTER;
+        snprintf(netif_jobs[5].job.name, sizeof(netif_jobs[5].job.name) - 1, "%s", "kni_master_proc");
+        netif_jobs[5].job.func = kni_process_on_master;
+        netif_jobs[5].job.data = NULL;
+        netif_jobs[5].job.type = LCORE_JOB_LOOP;
+    } else {
+        netif_jobs[5].role = LCORE_ROLE_KNI_WORKER;
+        snprintf(netif_jobs[5].job.name, sizeof(netif_jobs[5].job.name) - 1, "%s", "kni_loop");
+        netif_jobs[5].job.func = kni_lcore_loop;
+        netif_jobs[5].job.data = NULL;
+        netif_jobs[5].job.type = LCORE_JOB_LOOP;
+    }
 
     for (ii = 0; ii < NETIF_JOB_MAX; ii++) {
         res = dpvs_lcore_job_register(&netif_jobs[ii].job, netif_jobs[ii].role);
@@ -2583,11 +2641,30 @@ static inline void free_mbufs(struct rte_mbuf **pkts, unsigned num)
     }
 }
 
-static void kni_ingress(struct rte_mbuf *mbuf, struct netif_port *dev,
-                        struct netif_queue_conf *qconf)
+static inline void kni_ingress_pkts_redirect(struct netif_port *dev,
+                                             struct netif_queue_conf *qconf)
 {
     unsigned pkt_num;
 
+    if (g_kni_lcore_id) {
+        pkt_num = rte_ring_enqueue_burst(dev->kni.rx_ring, (void *)qconf->kni_mbufs,
+                                         qconf->kni_len, NULL);
+    } else {
+        rte_spinlock_lock(&kni_lock);
+        pkt_num = rte_kni_tx_burst(dev->kni.kni, qconf->kni_mbufs, qconf->kni_len);
+        rte_spinlock_unlock(&kni_lock);
+    }
+
+    if (unlikely(pkt_num < qconf->kni_len)) {
+        RTE_LOG(WARNING, NETIF, "%s: fail to send pkts to kni\n", __func__);
+        free_mbufs(&(qconf->kni_mbufs[pkt_num]), qconf->kni_len - pkt_num);
+    }
+    qconf->kni_len = 0;
+}
+
+static void kni_ingress(struct rte_mbuf *mbuf, struct netif_port *dev,
+                        struct netif_queue_conf *qconf)
+{
     if (!kni_dev_exist(dev)) {
         rte_pktmbuf_free(mbuf);
         return;
@@ -2603,40 +2680,24 @@ static void kni_ingress(struct rte_mbuf *mbuf, struct netif_port *dev,
     /* VLAN device cannot be scheduled by kni_send2kern_loop */
     if ((dev->type == PORT_TYPE_VLAN && qconf->kni_len > 0) ||
         unlikely(qconf->kni_len == NETIF_MAX_PKT_BURST)) {
-        rte_spinlock_lock(&kni_lock);
-        pkt_num = rte_kni_tx_burst(dev->kni.kni, qconf->kni_mbufs, qconf->kni_len);
-        rte_spinlock_unlock(&kni_lock);
-
-        if (unlikely(pkt_num < qconf->kni_len)) {
-            RTE_LOG(WARNING, NETIF, "%s: fail to send pkts to kni\n", __func__);
-            free_mbufs(&(qconf->kni_mbufs[pkt_num]), qconf->kni_len - pkt_num);
-        }
-
-        qconf->kni_len = 0;
+            kni_ingress_pkts_redirect(dev, qconf);
     }
 }
 
 static void kni_send2kern_loop(uint8_t port_id, struct netif_queue_conf *qconf)
 {
     struct netif_port *dev;
-    unsigned pkt_num;
 
     dev = netif_port_get(port_id);
 
     if (qconf->kni_len > 0) {
         if (kni_dev_exist(dev)) {
-            rte_spinlock_lock(&kni_lock);
-            pkt_num = rte_kni_tx_burst(dev->kni.kni, qconf->kni_mbufs, qconf->kni_len);
-            rte_spinlock_unlock(&kni_lock);
+            kni_ingress_pkts_redirect(dev, qconf);
         } else {
-            pkt_num = 0;
+            RTE_LOG(WARNING, NETIF, "kni of dev: %s does not exist.\n", dev->name);
+            free_mbufs(qconf->kni_mbufs, qconf->kni_len);
+            qconf->kni_len = 0;
         }
-
-        if (unlikely(pkt_num < qconf->kni_len)) {
-            RTE_LOG(WARNING, NETIF, "%s: fail to send pkts to kni\n", __func__);
-            free_mbufs(&(qconf->kni_mbufs[pkt_num]), qconf->kni_len - pkt_num);
-        }
-        qconf->kni_len = 0;
     }
 }
 
@@ -2658,7 +2719,7 @@ static void kni_send2port_loop(struct netif_port *port)
         netif_xmit(kni_pkts_burst[i], port);
 }
 
-static void kni_process_on_master(void *dummy)
+static void kni_egress_process(void)
 {
     struct netif_port *dev;
     portid_t id;
@@ -2671,6 +2732,55 @@ static void kni_process_on_master(void *dummy)
         kni_handle_request(dev);
         kni_send2port_loop(dev);
     }
+}
+
+void kni_process_on_master(void *dummy)
+{
+    /* Skip master core process for KNI if KNI lcore is configured. */
+    if (g_kni_lcore_id == 0)
+        kni_egress_process();
+}
+
+/*
+ * KNI rx rte_ring use mode as multi-producers and the single-consumer.
+ */
+static void kni_ingress_process(void)
+{
+    struct rte_mbuf *mbufs[NETIF_MAX_PKT_BURST];
+    struct netif_port *dev;
+    uint16_t nb_rb;
+    uint16_t pkt_num;
+    portid_t id;
+
+    for (id = 0; id < g_nports; id++) {
+        dev = netif_port_get(id);
+        if (!dev || !kni_dev_exist(dev))
+            continue;
+
+        nb_rb = rte_ring_dequeue_burst(dev->kni.rx_ring, (void**)mbufs,
+                                       NETIF_MAX_PKT_BURST, NULL);
+        if (nb_rb == 0)
+            continue;
+        pkt_num = rte_kni_tx_burst(dev->kni.kni, mbufs, nb_rb);
+
+        if (unlikely(pkt_num < nb_rb)) {
+        #ifdef CONFIG_DPVS_NETIF_DEBUG
+            RTE_LOG(INFO, NETIF,
+                    "%s: fail to send pkts to kni from kni rte ring\n", __func__);
+        #endif
+            free_mbufs(&(mbufs[pkt_num]), nb_rb - pkt_num);
+        }
+        nb_rb = 0;
+    }
+}
+
+/*
+ * Use separate core to convey kni traffic if KNI lcore worker is configued.
+ */
+void kni_lcore_loop(void *dummy)
+{
+    kni_ingress_process();
+    kni_egress_process();
 }
 
 /********************************************* port *************************************************/
@@ -4179,6 +4289,7 @@ static int get_lcore_mask(void **out, size_t *out_len)
         return EDPVS_NOMEM;
 
     get->master_lcore_id = g_master_lcore_id;
+    get->kni_lcore_id = g_kni_lcore_id;
     get->slave_lcore_num = g_slave_lcore_num;
     get->slave_lcore_mask = g_slave_lcore_mask;
     get->isol_rx_lcore_num = g_isol_rx_lcore_num;
@@ -4319,7 +4430,7 @@ static int get_lcore_stats(lcoreid_t cid, void **out, size_t *out_len)
     if (unlikely(!get))
         return EDPVS_NOMEM;
 
-    if (is_isol_rxq_lcore(cid)) {
+    if (is_isol_rxq_lcore(cid) || is_kni_lcore(cid)) {
         /* use write lock to ensure data safety */
         memcpy(&stats, &lcore_stats[cid], sizeof(stats));
     } else {

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -37,6 +37,7 @@ const char *dpvs_lcore_role_str(dpvs_lcore_role_t role)
         [LCORE_ROLE_MASTER]        = "lcre_role_master",
         [LCORE_ROLE_FWD_WORKER]    = "lcre_role_fwd_worker",
         [LCORE_ROLE_ISOLRX_WORKER] = "lcre_role_isolrx_worker",
+        [LCORE_ROLE_KNI_WORKER]    = "lcore_role_kni_worker",
         [LCORE_ROLE_MAX]           = "lcre_role_null"
     };
 

--- a/tools/dpip/link.c
+++ b/tools/dpip/link.c
@@ -745,6 +745,14 @@ static int link_show(struct link_param *param)
                             lcores.master_lcore_id);
                     ret = err;
                 }
+                if (lcores.kni_lcore_id) {
+                    err = link_cpu_show(lcores.kni_lcore_id, param);
+                    if (err) {
+                        fprintf(stderr, "Fail to get information for KNI cpu%d\n",
+                                lcores.kni_lcore_id);
+                        ret = err;
+                    }
+                }
 
                 printf("<< Data Plane >>\n");
                 cnt = 0;


### PR DESCRIPTION
1. It use multiple producers and single consumer rte ring to send packets to
kni interface and master core will not handle kni tx traffic again.
2. Global lock kni_lock can be removed if kni worker is configured.
3. kni will use specified tx queue to send packets.

Hopefully, this will enlarge kni bandwith and improve performance.