### PR TITLE
fix per lcore need mcast init

### DIFF
--- a/include/inetaddr.h
+++ b/include/inetaddr.h
@@ -117,7 +117,7 @@ bool inet_chk_mcast_addr(int af, struct netif_port *dev,
 
 void inet_ifaddr_dad_failure(struct inet_ifaddr *ifa);
 
-int idev_add_mcast_init(struct netif_port *dev);
+int idev_add_mcast_init(void *args);
 
 int inet_addr_init(void);
 int inet_addr_term(void);

--- a/src/inetaddr.c
+++ b/src/inetaddr.c
@@ -214,12 +214,14 @@ static int ifa_add_del_mcast(struct inet_ifaddr *ifa, bool add)
 }
 
 /* add ipv6 multicast address after port start */
-int idev_add_mcast_init(struct netif_port *dev)
+int idev_add_mcast_init(void *args)
 {
     int err;
     struct inet_device *idev;
     union inet_addr all_nodes, all_routers;
     struct ether_addr eaddr_nodes, eaddr_routers;
+
+    struct netif_port *dev = (struct netif_port *) args;
 
     idev = dev_get_idev(dev);
 


### PR DESCRIPTION
Need invoke `idev_add_mcast_init` in all lcore, otherwise lcore cannot handle ICMP6 neighbor advertisement packet which ipv6 dst is `ff02::1` or `ff02::2`. Because in `ip6_mc_local_in` function it will invoke `inet_chk_mcast_addr` to check ipv6 dst and it will failed, so the packet will deliver to KNI.