### PR TITLE
conf: move the types of portid_t and queueid_t to conf/common.h.

### DIFF
--- a/include/conf/common.h
+++ b/include/conf/common.h
@@ -75,6 +75,13 @@ typedef uint32_t    __u32;
 typedef uint8_t lcoreid_t;
 #endif
 
+#ifndef portid_t
+typedef uint16_t portid_t;
+#endif
+
+#ifndef queueid_t
+typedef uint16_t queueid_t;
+#endif
 
 #define DPVS_WAIT_WHILE(expr) while(expr){;}
 

--- a/include/conf/netif.h
+++ b/include/conf/netif.h
@@ -29,10 +29,6 @@
 #define RTE_ETHDEV_QUEUE_STAT_CNTRS     16
 #define NETIF_MAX_BOND_SLAVES           32
 
-typedef uint8_t lcoreid_t;
-typedef uint16_t portid_t;
-typedef uint16_t queueid_t;
-
 /*** end of type from dpdk.h ***/
 
 enum {

--- a/include/dpdk.h
+++ b/include/dpdk.h
@@ -62,17 +62,12 @@
 #include <rte_pdump.h>
 #endif
 
-typedef uint8_t lcoreid_t;
-typedef uint16_t portid_t;
-typedef uint16_t queueid_t;
-
-
 #ifdef RTE_LOG
 extern int dpvs_log(uint32_t level, uint32_t logtype, const char *func, int line, const char *format, ...);
 #undef RTE_LOG
 #define RTE_LOG(l, t, ...)                  \
     dpvs_log(RTE_LOG_ ## l,                   \
-        RTE_LOGTYPE_ ## t,  __func__, __LINE__, # t ": " __VA_ARGS__) 
+        RTE_LOGTYPE_ ## t,  __func__, __LINE__, # t ": " __VA_ARGS__)
 #endif
 
 


### PR DESCRIPTION
- Both conf/netif.h and include/dpdk.h define the same below types.
a) lcoreid_t
b) portid_t
c) queueid_t

Move the above types to the same header file, conf/common.h instead of
definiting them in two header files.