### PR TITLE
Reuse expired ifa during adding ifa.

### DIFF
--- a/include/sa_pool.h
+++ b/include/sa_pool.h
@@ -42,10 +42,65 @@
 #ifndef __DPVS_SA_POOL__
 #define __DPVS_SA_POOL__
 
+#define MAX_PORT            65536
+
+#define MAX_FDIR_PROTO      2
+
 struct sa_pool_stats {
     uint32_t used_cnt;
     uint32_t free_cnt;
     uint32_t miss_cnt;
+};
+
+/**
+ * if really need to to save memory, we can;
+ * 1. use hlist_head
+ * 2. use uint8_t flag
+ * 3. remove sa_entry.addr, and get IP from sa_pool->ifa
+ * 4. to __packed__ sa_entry.
+ * 5. alloc sa_entries[] for 65536/cpu_num only.
+ * 6. create sa_entry_pool only if pool_hash hit.
+ *    since when dest (like RS) num may small.
+ */
+
+/* socket address (sa) is <ip, port> pair. */
+struct sa_entry {
+    struct list_head        list;       /* node of sa_pool. */
+    uint32_t                flags;      /* SA_F_XXX */
+    union inet_addr         addr;
+    __be16                  port;
+};
+
+struct sa_entry_pool {
+    struct sa_entry         sa_entries[MAX_PORT];
+    struct list_head        used_enties;
+    struct list_head        free_enties;
+    /* another way is use total_used/free_cnt in sa_pool,
+     * so that we need not travels the hash to get stats.
+     * we use cnt here, since we may need per-pool stats. */
+    uint16_t                used_cnt;
+    uint16_t                free_cnt;
+    uint32_t                miss_cnt;
+};
+
+/* no lock needed because inet_ifaddr.sa_pool
+ * is per-lcore. */
+struct sa_pool {
+    struct inet_ifaddr      *ifa;       /* back-pointer */
+
+    uint16_t                low;        /* min port */
+    uint16_t                high;       /* max port */
+    rte_atomic32_t          refcnt;
+
+    /* hashed pools by dest's <ip/port>. if no dest provided,
+     * just use first pool. it's not need create/destroy pool
+     * for each dest, that'll be too complicated. */
+    struct sa_entry_pool    *pool_hash;
+    uint8_t                 pool_hash_sz;
+    uint32_t                flags;      /* SA_POOL_F_XXX */
+
+    /* fdir filter ID */
+    uint32_t                filter_id[MAX_FDIR_PROTO];
 };
 
 int sa_pool_init(void);
@@ -69,9 +124,12 @@ int sa_release(const struct netif_port *dev,
 int get_sa_pool_stats(const struct inet_ifaddr *ifa,
                        struct sa_pool_stats *stats);
 
-void inc_sa_pool_refcnt(struct inet_ifaddr *ifa);
-
 /* config file */
 void install_sa_pool_keywords(void);
+
+static inline void hold_ifa_sa_pool(struct inet_ifaddr *ifa)
+{
+    rte_atomic32_inc(&ifa->sa_pool->refcnt);
+}
 
 #endif /* __DPVS_SA_POOL__ */

--- a/include/sa_pool.h
+++ b/include/sa_pool.h
@@ -69,6 +69,8 @@ int sa_release(const struct netif_port *dev,
 int get_sa_pool_stats(const struct inet_ifaddr *ifa,
                        struct sa_pool_stats *stats);
 
+void inc_sa_pool_refcnt(struct inet_ifaddr *ifa);
+
 /* config file */
 void install_sa_pool_keywords(void);
 

--- a/src/sa_pool.c
+++ b/src/sa_pool.c
@@ -858,6 +858,10 @@ int get_sa_pool_stats(const struct inet_ifaddr *ifa, struct sa_pool_stats *stats
     return EDPVS_OK;
 }
 
+void inc_sa_pool_refcnt(struct inet_ifaddr *ifa) {
+    rte_atomic32_inc(&ifa->sa_pool->refcnt);
+}
+
 int sa_pool_init(void)
 {
     int shift;


### PR DESCRIPTION
**BUG Scenario:** 

We use DPVS for nat64,  BUG stable reproduction steps:

1. Add local ip
2. Make some packet, such as udp traffic.
3. Delete local ip
4. Loop the above steps
5. Repeat the cycle sveral times, and then traffic disconnected

And  `dpip addr show -v`  show that miss some ifa in lcore:
- We use 4 local ip:  192.168.202.110, 192.168.202.109, 192.168.202.108, 192.168.202.107
- Master core: 2; slave lcore: 3,4,5,6
- When traffic disconnected, `dpip addr show -v` show that slave lcore miss ifa, which make nat64 failed.
- Master core had all ifa.

```
~# dpvsadm --get-laddr
VIP:VPORT            TOTAL    SNAT_IP              CONFLICTS  CONNS
[::]:0               4
                              192.168.202.106      0          0
                              192.168.202.105      0          0
                              192.168.202.104      0          0
                              192.168.202.103      0          0

~# dpip addr show -v
[02] inet 192.168.202.105/32 scope global kni1
     valid_lft forever preferred_lft forever sa_used 0 sa_free 1032176 sa_miss 0
[02] inet 192.168.202.106/32 scope global kni1
     valid_lft forever preferred_lft forever sa_used 0 sa_free 1032176 sa_miss 0
[02] inet 192.168.202.103/32 scope global kni1
     valid_lft forever preferred_lft forever sa_used 0 sa_free 516080 sa_miss 0
[02] inet 192.168.202.104/32 scope global kni1
     valid_lft forever preferred_lft forever sa_used 0 sa_free 516080 sa_miss 0
[02] inet6 2001:db8::110/64 scope global kni0
     valid_lft forever preferred_lft forever
     
[04] inet6 2001:db8::110/64 scope global kni0
     valid_lft forever preferred_lft forever

[06] inet 192.168.202.106/32 scope global kni1
     valid_lft forever preferred_lft forever sa_used 1 sa_free 258047 sa_miss 0
[06] inet6 2001:db8::110/64 scope global kni0
     valid_lft forever preferred_lft forever

[05] inet6 2001:db8::110/64 scope global kni0
     valid_lft forever preferred_lft forever

[03] inet 192.168.202.106/32 scope global kni1
     valid_lft forever preferred_lft forever sa_used 4 sa_free 258028 sa_miss 0
[03] inet6 2001:db8::110/64 scope global kni0
     valid_lft forever preferred_lft forever
```

And we can see some dpvs log:

```
!NETIF: dpdk_set_fdir_filt: fdir filt set failed for kni1 -- File exists(-17)
!NETIF: dpdk_set_fdir_filt: fdir filt set failed for kni1 -- File exists(-17)
!IFA: [05] ifa_entry_add: add ifaddr 192.168.202.106 failed -- failed dpdk api
IFA: [03] ifa_entry_add: add ifaddr 192.168.202.106 failed -- failed dpdk api
```

The log mean invoke `dpdk_set_fdir_filt` failed, and lead ifa add failed. This is the reason why slave lcore miss some ifa.

`fdir filt set failed for kni1` log happend because fdir not deleted by deleting local ip. The reason why not deleted fdir is still some conn not expired, and cannot delete fdir when delete ifa. So that add ifa before conn expired will be failed and show above log.

```
// delete ifa invoke
int sa_pool_destroy(struct inet_ifaddr *ifa)
{
    // ...
    ap = ifa->sa_pool;

    if (!rte_atomic32_dec_and_test(&ap->refcnt)) // conn is not expired, ap->refcnt is not 1
        return EDPVS_OK; // return here

		// not deleted fdir
    err = sa_del_filter(ifa->af, ifa->idev->dev, cid, &ifa->addr,
            sa_fdirs[cid].port_base, ap->filter_id); /* thread-safe ? */
    // ...
```

**Fix this problem by reuse expired ifa from `ifa_expired_list` during adding ifa.**