### PR TITLE
fix build error in gcc 7.3.0

### DIFF
--- a/src/iftraf.c
+++ b/src/iftraf.c
@@ -387,7 +387,7 @@ int iftraf_sockopt_get(sockoptid_t opt, const void *conf, size_t size,
 
     if (!conf || size < sizeof(struct dp_vs_iftraf_conf) || !out || !outsize)
         return EDPVS_INVAL;
-	cf = conf;
+    cf = conf;
 
     if (cf && strlen(cf->ifname)) {
         port = netif_port_get_by_name(cf->ifname);


### PR DESCRIPTION
Fix build error
/root/dpvs/dpvs-master/src/iftraf.c: In function ‘iftraf_sockopt_get’:
/root/dpvs/dpvs-master/src/iftraf.c:388:5: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
     if (!conf || size < sizeof(struct dp_vs_iftraf_conf) || !out || !outsize)
     ^~
/root/dpvs/dpvs-master/src/iftraf.c:390:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  cf = conf;
  ^~
