### PR TITLE
sockopts: Centralize all the SOCKOPT_SET/GET_XXX definitions into one…

### DIFF
--- a/include/conf/blklst.h
+++ b/include/conf/blklst.h
@@ -21,16 +21,9 @@
  */
 #ifndef __DPVS_BLKLST_CONF_H__
 #define __DPVS_BLKLST_CONF_H__
-#include "inet.h"
 
-enum {
-    /* set */
-    SOCKOPT_SET_BLKLST_ADD  = 700,
-    SOCKOPT_SET_BLKLST_DEL,
-    SOCKOPT_SET_BLKLST_FLUSH,
-    /* get */
-    SOCKOPT_GET_BLKLST_GETALL,
-};
+#include "inet.h"
+#include "conf/sockopts.h"
 
 struct dp_vs_blklst_entry {
     union inet_addr addr;

--- a/include/conf/conn.h
+++ b/include/conf/conn.h
@@ -18,14 +18,15 @@
 
 #ifndef __DPVS_CONN_CONF_H__
 #define __DPVS_CONN_CONF_H__
+
 #include "list.h"
 #include "inet.h"
+#include "conf/sockopts.h"
 
 /* How many connections returned at most for one sockopt ctrl msg.
  * Decrease it for saving memory, increase it for better performace.
  */
 #define MAX_CTRL_CONN_GET_ENTRIES       1024
-
 
 enum conn_get_flags {
     GET_IPVS_CONN_FLAG_ALL          = 1,
@@ -39,12 +40,6 @@ enum conn_get_result {
     GET_IPVS_CONN_RESL_MORE         = 2,
     GET_IPVS_CONN_RESL_FAIL         = 4,
     GET_IPVS_CONN_RESL_NOTEXIST     = 8,
-};
-
-enum {
-    /* get */
-    SOCKOPT_GET_CONN_ALL = 1000,
-    SOCKOPT_GET_CONN_SPECIFIED,
 };
 
 struct ip_vs_sockpair {

--- a/include/conf/iftraf.h
+++ b/include/conf/iftraf.h
@@ -17,18 +17,11 @@
  */
 #ifndef __DPVS_IFTRAF_CONF_H__
 #define __DPVS_IFTRAF_CONF_H__
+
 #include <stdint.h>
 #include <linux/if_addr.h>
 #include "inet.h"
-
-enum {
-    /* set */
-    SOCKOPT_SET_IFTRAF_ADD = 6400,
-    SOCKOPT_SET_IFTRAF_DEL,
-
-    /* get */
-    SOCKOPT_GET_IFTRAF_SHOW,
-};
+#include "conf/sockopts.h"
 
 struct dp_vs_iftraf_conf {
     char ifname[IFNAMSIZ];

--- a/include/conf/inetaddr.h
+++ b/include/conf/inetaddr.h
@@ -17,21 +17,12 @@
  */
 #ifndef __DPVS_INETADDR_CONF_H__
 #define __DPVS_INETADDR_CONF_H__
+
 #include <stdint.h>
 #include <linux/if_addr.h>
 #include "inet.h"
 #include "net/if.h"
-
-enum {
-    /* set */
-    SOCKOPT_SET_IFADDR_ADD  = 400,
-    SOCKOPT_SET_IFADDR_DEL,
-    SOCKOPT_SET_IFADDR_SET,
-    SOCKOPT_SET_IFADDR_FLUSH,
-
-    /* get */
-    SOCKOPT_GET_IFADDR_SHOW,
-};
+#include "conf/sockopts.h"
 
 enum {
     IFA_SCOPE_GLOBAL        = 0,

--- a/include/conf/ip_tunnel.h
+++ b/include/conf/ip_tunnel.h
@@ -24,9 +24,11 @@
  */
 #ifndef __DPVS_TUNNEL_CONF_H__
 #define __DPVS_TUNNEL_CONF_H__
+
 #include <net/if.h>
 #include <netinet/ip.h>
 #include <endian.h>
+#include "conf/sockopts.h"
 
 #define TNLKINDSIZ              16
 
@@ -45,17 +47,6 @@
 #define TUNNEL_F_VXLAN_OPT      htobe16(0x1000)
 #define TUNNEL_F_NOCACHE        htobe16(0x2000)
 #define TUNNEL_F_ERSPAN_OPT     htobe16(0x4000)
-
-enum {
-    /* set */
-    SOCKOPT_TUNNEL_ADD          = 1000,
-    SOCKOPT_TUNNEL_DEL,
-    SOCKOPT_TUNNEL_CHANGE,
-    SOCKOPT_TUNNEL_REPLACE,
-
-    /* get */
-    SOCKOPT_TUNNEL_SHOW,
-};
 
 struct ip_tunnel_param {
     char            ifname[IFNAMSIZ];

--- a/include/conf/ipset.h
+++ b/include/conf/ipset.h
@@ -22,15 +22,7 @@
 #ifndef __DPVS_IPSET_CONF_H__
 #define __DPVS_IPSET_CONF_H__
 
-enum {
-    /* set */
-    SOCKOPT_SET_IPSET_ADD   = 3300,
-    SOCKOPT_SET_IPSET_DEL,
-    SOCKOPT_SET_IPSET_FLUSH,
-
-    /* get */
-    SOCKOPT_GET_IPSET_SHOW,
-};
+#include "conf/sockopts.h"
 
 struct dp_vs_ipset_conf {
 	int af;

--- a/include/conf/ipv6.h
+++ b/include/conf/ipv6.h
@@ -22,14 +22,9 @@
  */
 #ifndef __DPVS_IPV6_CONF_H__
 #define __DPVS_IPV6_CONF_H__
-#include "inet.h"
 
-enum {
-    /* set */
-    SOCKOPT_IP6_SET = 1100,
-    /* get */
-    SOCKOPT_IP6_STATS,
-};
+#include "inet.h"
+#include "conf/sockopts.h"
 
 struct ip6_stats_param {
     struct inet_stats stats;

--- a/include/conf/laddr.h
+++ b/include/conf/laddr.h
@@ -21,18 +21,10 @@
  */
 #ifndef __DPVS_LADDR_CONF_H__
 #define __DPVS_LADDR_CONF_H__
+
 #include "inet.h"
 #include "net/if.h"
-
-enum {
-    /* set */
-    SOCKOPT_SET_LADDR_ADD   = 100,
-    SOCKOPT_SET_LADDR_DEL,
-    SOCKOPT_SET_LADDR_FLUSH,
-
-    /* get */
-    SOCKOPT_GET_LADDR_GETALL,
-};
+#include "conf/sockopts.h"
 
 #define SOCKOPT_LADDR_BASE SOCKOPT_SET_LADDR_ADD
 #define SOCKOPT_GET_LADDR_MAX 199

--- a/include/conf/neigh.h
+++ b/include/conf/neigh.h
@@ -21,15 +21,7 @@
 #include <arpa/inet.h>
 #include <net/if.h>
 #include "inet.h"
-
-enum {
-    /* get */
-    SOCKOPT_GET_NEIGH_SHOW = 600,
-
-    /* set */
-    SOCKOPT_SET_NEIGH_ADD,
-    SOCKOPT_SET_NEIGH_DEL,
-};
+#include "conf/sockopts.h"
 
 enum {
     DPVS_NUD_S_NONE        = 0,

--- a/include/conf/netif.h
+++ b/include/conf/netif.h
@@ -17,8 +17,10 @@
  */
 #ifndef __NETIF_CONF_H__
 #define __NETIF_CONF_H__
+
 #include <linux/if_ether.h>
 #include <net/if.h>
+#include "conf/sockopts.h"
 
 #define NETIF_MAX_PORTS     4096
 
@@ -30,24 +32,6 @@
 #define NETIF_MAX_BOND_SLAVES           32
 
 /*** end of type from dpdk.h ***/
-
-enum {
-    /* get */
-    SOCKOPT_NETIF_GET_LCORE_MASK = 500,
-    SOCKOPT_NETIF_GET_LCORE_BASIC,
-    SOCKOPT_NETIF_GET_LCORE_STATS,
-    SOCKOPT_NETIF_GET_PORT_LIST,
-    SOCKOPT_NETIF_GET_PORT_BASIC,
-    SOCKOPT_NETIF_GET_PORT_STATS,
-    SOCKOPT_NETIF_GET_PORT_EXT_INFO,
-    SOCKOPT_NETIF_GET_BOND_STATUS,
-    SOCKOPT_NETIF_GET_MAX,
-    /* set */
-    SOCKOPT_NETIF_SET_LCORE = 500,
-    SOCKOPT_NETIF_SET_PORT,
-    SOCKOPT_NETIF_SET_BOND,
-    SOCKOPT_NETIF_SET_MAX,
-};
 
 /* all lcores in use */
 typedef struct netif_lcore_mask_get

--- a/include/conf/route.h
+++ b/include/conf/route.h
@@ -21,19 +21,10 @@
  */
 #ifndef __DPVS_ROUTE_CONF_H__
 #define __DPVS_ROUTE_CONF_H__
+
 #include "inet.h"
 #include "net/if.h"
-
-enum {
-    /* set */
-    SOCKOPT_SET_ROUTE_ADD   = 300,
-    SOCKOPT_SET_ROUTE_DEL,
-    SOCKOPT_SET_ROUTE_SET,
-    SOCKOPT_SET_ROUTE_FLUSH,
-
-    /* get */
-    SOCKOPT_GET_ROUTE_SHOW,
-};
+#include "conf/sockopts.h"
 
 enum {
     ROUTE_CF_SCOPE_NONE     = 0,

--- a/include/conf/route6.h
+++ b/include/conf/route6.h
@@ -20,15 +20,7 @@
 #define __DPVS_ROUTE6_CONF_H__
 
 #include "flow.h"
-
-enum {
-    /* set */
-    SOCKOPT_SET_ROUTE6_ADD_DEL  = 6300,
-    SOCKOPT_SET_ROUTE6_FLUSH,
-
-    /* get */
-    SOCKOPT_GET_ROUTE6_SHOW     = 6300,
-};
+#include "conf/sockopts.h"
 
 enum {
     RT6_OPS_GET = 1,

--- a/include/conf/service.h
+++ b/include/conf/service.h
@@ -24,6 +24,7 @@
 #include "conf/match.h"
 #include "conf/stats.h"
 #include "conf/dest.h"
+#include "conf/sockopts.h"
 
 #define DP_VS_SCHEDNAME_MAXLEN      16
 
@@ -106,32 +107,6 @@ struct dp_vs_getinfo {
     unsigned int num_services;
     unsigned int num_lcores;
 };
-
-enum{
-    DPVS_SO_SET_FLUSH = 200,
-    DPVS_SO_SET_ZERO,
-    DPVS_SO_SET_ADD,
-    DPVS_SO_SET_EDIT,
-    DPVS_SO_SET_DEL,
-    DPVS_SO_SET_ADDDEST,
-    DPVS_SO_SET_EDITDEST,
-    DPVS_SO_SET_DELDEST,
-    DPVS_SO_SET_GRATARP,
-};
-
-enum{
-    DPVS_SO_GET_VERSION = 200,
-    DPVS_SO_GET_INFO,
-    DPVS_SO_GET_SERVICES,
-    DPVS_SO_GET_SERVICE,
-    DPVS_SO_GET_DESTS,
-};
-
-
-#define SOCKOPT_SVC_BASE         DPVS_SO_SET_FLUSH
-#define SOCKOPT_SVC_SET_CMD_MAX  DPVS_SO_SET_GRATARP
-#define SOCKOPT_SVC_GET_CMD_MAX  DPVS_SO_GET_DESTS
-#define SOCKOPT_SVC_MAX          299
 
 #define MAX_ARG_LEN    (sizeof(struct dp_vs_service_user) +    \
                          sizeof(struct dp_vs_dest_user))

--- a/include/conf/sockopts.h
+++ b/include/conf/sockopts.h
@@ -1,0 +1,135 @@
+/*
+ * DPVS is a software load balancer (Virtual Server) based on DPDK.
+ *
+ * Copyright (C) 2017 iQIYI (www.iqiyi.com).
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+#ifndef __DPVS_SOCKOPTS_CONF_H__
+#define __DPVS_SOCKOPTS_CONF_H__
+
+typedef enum {
+    /* tc */
+    SOCKOPT_TC_ADD  = 900,
+    SOCKOPT_TC_DEL,
+    SOCKOPT_TC_CHANGE,
+    SOCKOPT_TC_REPLACE,
+    SOCKOPT_TC_SHOW = 900,
+} tc_oper_t;
+
+enum {
+    /* laddr */
+    SOCKOPT_SET_LADDR_ADD    = 100,
+    SOCKOPT_SET_LADDR_DEL,
+    SOCKOPT_SET_LADDR_FLUSH,
+    SOCKOPT_GET_LADDR_GETALL = 100,
+
+    /* service */
+    DPVS_SO_SET_FLUSH   = 200,
+    DPVS_SO_SET_ZERO,
+    DPVS_SO_SET_ADD,
+    DPVS_SO_SET_EDIT,
+    DPVS_SO_SET_DEL,
+    DPVS_SO_SET_ADDDEST,
+    DPVS_SO_SET_EDITDEST,
+    DPVS_SO_SET_DELDEST,
+    DPVS_SO_SET_GRATARP,
+    DPVS_SO_GET_VERSION = 200,
+    DPVS_SO_GET_INFO,
+    DPVS_SO_GET_SERVICES,
+    DPVS_SO_GET_SERVICE,
+    DPVS_SO_GET_DESTS,
+#define SOCKOPT_SVC_BASE         DPVS_SO_SET_FLUSH
+#define SOCKOPT_SVC_SET_CMD_MAX  DPVS_SO_SET_GRATARP
+#define SOCKOPT_SVC_GET_CMD_MAX  DPVS_SO_GET_DESTS
+#define SOCKOPT_SVC_MAX          299
+
+    /* route */
+    SOCKOPT_SET_ROUTE_ADD   = 300,
+    SOCKOPT_SET_ROUTE_DEL,
+    SOCKOPT_SET_ROUTE_SET,
+    SOCKOPT_SET_ROUTE_FLUSH,
+    SOCKOPT_GET_ROUTE_SHOW  = 300,
+
+    /* ifaddr */
+    SOCKOPT_SET_IFADDR_ADD  = 400,
+    SOCKOPT_SET_IFADDR_DEL,
+    SOCKOPT_SET_IFADDR_SET,
+    SOCKOPT_SET_IFADDR_FLUSH,
+    SOCKOPT_GET_IFADDR_SHOW = 400,
+
+    /* netif */
+    SOCKOPT_NETIF_SET_LCORE      = 500,
+    SOCKOPT_NETIF_SET_PORT,
+    SOCKOPT_NETIF_SET_BOND,
+    SOCKOPT_NETIF_SET_MAX,
+    SOCKOPT_NETIF_GET_LCORE_MASK = 500,
+    SOCKOPT_NETIF_GET_LCORE_BASIC,
+    SOCKOPT_NETIF_GET_LCORE_STATS,
+    SOCKOPT_NETIF_GET_PORT_LIST,
+    SOCKOPT_NETIF_GET_PORT_BASIC,
+    SOCKOPT_NETIF_GET_PORT_STATS,
+    SOCKOPT_NETIF_GET_PORT_EXT_INFO,
+    SOCKOPT_NETIF_GET_BOND_STATUS,
+    SOCKOPT_NETIF_GET_MAX,
+
+    /* neigh */
+    SOCKOPT_SET_NEIGH_ADD     = 600,
+    SOCKOPT_SET_NEIGH_DEL,
+    SOCKOPT_GET_NEIGH_SHOW    = 600,
+
+    /* blklst */
+    SOCKOPT_SET_BLKLST_ADD    = 700,
+    SOCKOPT_SET_BLKLST_DEL,
+    SOCKOPT_SET_BLKLST_FLUSH,
+    SOCKOPT_GET_BLKLST_GETALL = 700,
+
+    /* vlan */
+    SOCKOPT_SET_VLAN_ADD  = 800,
+    SOCKOPT_SET_VLAN_DEL,
+    SOCKOPT_GET_VLAN_SHOW = 800,
+
+    /* connection */
+    SOCKOPT_SET_CONN     = 1000,
+    SOCKOPT_GET_CONN_ALL = 1000,
+    SOCKOPT_GET_CONN_SPECIFIED,
+
+    /* ip6 */
+    SOCKOPT_IP6_SET = 1100,
+    SOCKOPT_IP6_STATS,
+
+    /* tunnel */
+    SOCKOPT_TUNNEL_ADD  = 1200,
+    SOCKOPT_TUNNEL_DEL,
+    SOCKOPT_TUNNEL_CHANGE,
+    SOCKOPT_TUNNEL_REPLACE,
+    SOCKOPT_TUNNEL_SHOW = 1200,
+
+    /* ipset */
+    SOCKOPT_SET_IPSET_ADD  = 3300,
+    SOCKOPT_SET_IPSET_DEL,
+    SOCKOPT_SET_IPSET_FLUSH,
+    SOCKOPT_GET_IPSET_SHOW = 3300,
+
+    /* route6 */
+    SOCKOPT_SET_ROUTE6_ADD_DEL = 6300,
+    SOCKOPT_SET_ROUTE6_FLUSH,
+    SOCKOPT_GET_ROUTE6_SHOW    = 6300,
+
+    /* iftraf */
+    SOCKOPT_SET_IFTRAF_ADD  = 6400,
+    SOCKOPT_SET_IFTRAF_DEL,
+    SOCKOPT_GET_IFTRAF_SHOW = 6400,
+};
+
+#endif /* __DPVS_SOCKOPTS_CONF_H__ */

--- a/include/conf/tc.h
+++ b/include/conf/tc.h
@@ -25,20 +25,10 @@
 #define __DPVS_TC_CONF_H__
 
 #include <linux/pkt_sched.h>
+#include "conf/sockopts.h"
 #include "tc/tc.h"
 #include "tc/sch.h"
 #include "tc/cls.h"
-
-typedef enum {
-    /* set */
-    SOCKOPT_TC_ADD = 900,
-    SOCKOPT_TC_DEL,
-    SOCKOPT_TC_CHANGE,
-    SOCKOPT_TC_REPLACE,
-
-    /* get */
-    SOCKOPT_TC_SHOW = 900,
-} tc_oper_t;
 
 typedef enum {
     TC_OBJ_QSCH,

--- a/include/conf/vlan.h
+++ b/include/conf/vlan.h
@@ -19,16 +19,8 @@
 #define __DPVS_VLAN_CONF_H__
 #include <stdint.h>
 #include <net/if.h>
+#include "conf/sockopts.h"
 #include "vlan.h"
-
-enum {
-    /* set */
-    SOCKOPT_SET_VLAN_ADD    = 800,
-    SOCKOPT_SET_VLAN_DEL,
-
-    /* get */
-    SOCKOPT_GET_VLAN_SHOW,
-};
 
 struct vlan_param {
     char        real_dev[IFNAMSIZ]; /* underlying device name */

--- a/src/ipvs/ip_vs_conn.c
+++ b/src/ipvs/ip_vs_conn.c
@@ -1576,8 +1576,8 @@ static int sockopt_conn_get(sockoptid_t opt, const void *in, size_t inlen,
 
 static struct dpvs_sockopts conn_sockopts = {
     .version        = SOCKOPT_VERSION,
-    .set_opt_min    = 0,
-    .set_opt_max    = 0,
+    .set_opt_min    = SOCKOPT_SET_CONN,
+    .set_opt_max    = SOCKOPT_SET_CONN,
     .set            = NULL,
     .get_opt_min    = SOCKOPT_GET_CONN_ALL,
     .get_opt_max    = SOCKOPT_GET_CONN_SPECIFIED,


### PR DESCRIPTION
… single file.

- The benefit is easy to define the definitons of SOCKOPT_SET/GET_YYY for a new
  module to avoid registering the same sockopt type instead of checking all the
  header files including the definitions of SOCKOPT_GET/SET_XXX.