### PR TITLE
add proxy_protocol_v2 support for fnat.

### DIFF
--- a/include/conf/pphdr.h
+++ b/include/conf/pphdr.h
@@ -1,0 +1,66 @@
+/*
+ * DPVS is a software load balancer (Virtual Server) based on DPDK.
+ *
+ * Copyright (C) 2017 iQIYI (www.iqiyi.com).
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+#ifndef __DPVS_PPHDR_H__
+#define __DPVS_PPHDR_H__
+
+#include <netinet/tcp.h>
+#include <stdint.h>
+
+#define PROXY_PROTO_HDR_LEN_V4 28
+#define PROXY_PROTO_HDR_LEN_V6 52
+
+#define PROXY_PROTO_V2_SIGNATURE "\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A"
+struct proxy_hdr_v2 {
+    uint8_t sig[12]; /* hex 0D 0A 0D 0A 00 0D 0A 51 55 49 54 0A */
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    uint8_t cmd:4,      /* 2:v2 */
+            ver:4;      /* 0:LOCAL, 1:PROXY */
+    uint8_t proto:4,    /* 0:UNSPEC, 1:STREAM, 2:DGRAM */
+            af:4;       /* 0:AF_UNIX, 1:AF_INET, 2:AF_INET6, 3:AF_UNIX */
+#elif __BYTE_ORDER == __BIG_ENDIAN
+    uint8_t ver:4,
+            cmd:4;
+    uint8_t af:4,
+            proto:4;
+#else
+#error "Please fix <bits/endian.h>"
+#endif
+    uint16_t addrlen;
+} __attribute__((__packed__));
+
+struct proxy_addr_ipv4{
+    uint32_t src_addr;
+    uint32_t dst_addr;
+    uint16_t src_port;
+    uint16_t dst_port;
+};
+
+struct proxy_addr_ipv6{
+    uint8_t src_addr[16];
+    uint8_t dst_addr[16];
+    uint16_t src_port;
+    uint16_t dst_port;
+};
+
+struct proxy_addr_unix{
+    uint8_t src_addr[108];
+    uint8_t dst_addr[108];
+};
+
+#endif /* __DPVS_PPHDR_H__ */
+

--- a/include/conf/service.h
+++ b/include/conf/service.h
@@ -44,6 +44,7 @@ struct dp_vs_service_conf {
     uint32_t            netmask;        /* persistent netmask */
     unsigned            bps;
     unsigned            limit_proportion;
+    uint32_t            proxy_protocol;
 };
 
 struct dp_vs_service_entry {
@@ -71,6 +72,7 @@ struct dp_vs_service_entry {
     char                drange[256];
     char                iifname[IFNAMSIZ];
     char                oifname[IFNAMSIZ];
+    uint32_t            proxy_protocol;
 };
 
 struct dp_vs_get_services {
@@ -98,6 +100,7 @@ struct dp_vs_service_user {
     char              drange[256];
     char              iifname[IFNAMSIZ];
     char              oifname[IFNAMSIZ];
+    uint32_t          proxy_protocol;
 };
 
 struct dp_vs_getinfo {

--- a/include/ipvs/conn.h
+++ b/include/ipvs/conn.h
@@ -44,6 +44,7 @@ enum {
     DPVS_CONN_F_SYNPROXY         = 0x8000,
     DPVS_CONN_F_TEMPLATE         = 0x1000,
     DPVS_CONN_F_NOFASTXMIT       = 0x2000,
+    DPVS_CONN_F_ONE_PACKET       = 0x0400,
 };
 
 struct dp_vs_conn_param {

--- a/include/ipvs/conn.h
+++ b/include/ipvs/conn.h
@@ -44,6 +44,7 @@ enum {
     DPVS_CONN_F_SYNPROXY         = 0x8000,
     DPVS_CONN_F_TEMPLATE         = 0x1000,
     DPVS_CONN_F_NOFASTXMIT       = 0x2000,
+    DPVS_CONN_F_WITH_PPHDR       = 0x0400,  /* proxy_protocol_v2 head flag */
 };
 
 struct dp_vs_conn_param {
@@ -55,6 +56,7 @@ struct dp_vs_conn_param {
     uint16_t            vport;
     uint16_t            ct_dport; /* RS port for template connection */
     bool                outwall;
+    bool                proxy_protocol;
 };
 
 struct conn_tuple_hash {
@@ -158,6 +160,8 @@ struct dp_vs_conn {
 
     /* flag for gfwip */
     bool outwall;
+    /* flag for proxy_protocol_v2*/
+    bool proxy_protocol;
 
 } __rte_cache_aligned;
 
@@ -333,6 +337,24 @@ static inline void
 dp_vs_conn_clear_redirect_hashed(struct dp_vs_conn *conn)
 {
     conn->flags &= ~DPVS_CONN_F_REDIRECT_HASHED;
+}
+ 
+static inline bool
+dp_vs_conn_is_with_pphdr(struct dp_vs_conn *conn)
+{
+    return (conn->flags & DPVS_CONN_F_WITH_PPHDR) ? true : false;
+}
+
+static inline void
+dp_vs_conn_set_with_pphdr(struct dp_vs_conn *conn)
+{
+    conn->flags |= DPVS_CONN_F_WITH_PPHDR;
+}
+
+static inline void
+dp_vs_conn_clear_with_pphdr(struct dp_vs_conn *conn)
+{
+    conn->flags &= ~DPVS_CONN_F_WITH_PPHDR;
 }
 
 uint32_t dp_vs_conn_hashkey(int af,

--- a/include/ipvs/proto_tcp.h
+++ b/include/ipvs/proto_tcp.h
@@ -105,5 +105,7 @@ void tcp6_send_csum(struct ipv6_hdr *iph, struct tcphdr *th);
 struct rte_mempool *get_mbuf_pool(const struct dp_vs_conn *conn, int dir);
 void install_proto_tcp_keywords(void);
 void tcp_keyword_value_init(void);
+void tcpopt_get_mss(int af, struct rte_mbuf *mbuf, uint16_t *mss);
+void tcpopt_update_mss(int af, struct rte_mbuf *mbuf, uint16_t new_mss);
 
 #endif

--- a/include/ipvs/proxy_protocol.h
+++ b/include/ipvs/proxy_protocol.h
@@ -1,0 +1,30 @@
+/*
+ * DPVS is a software load balancer (Virtual Server) based on DPDK.
+ *
+ * Copyright (C) 2017 iQIYI (www.iqiyi.com).
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+#ifndef __DPVS_PROXY_PROTOCOL_H__
+#define __DPVS_PROXY_PROTOCOL_H__
+
+#include "conf/pphdr.h"
+#include "conf/common.h"
+#include "ipvs/conn.h"
+
+/**************************** prototypes ******************************/
+
+int dp_vs_pphdr_inbound(struct rte_mbuf *mbuf, struct dp_vs_conn *conn);
+int dp_vs_pphdr_outbound(struct rte_mbuf *mbuf, struct dp_vs_conn *conn);
+
+#endif /* __DPVS_PROXY_PROTOCOL_H__ */

--- a/include/ipvs/service.h
+++ b/include/ipvs/service.h
@@ -34,6 +34,7 @@
 #define RTE_LOGTYPE_SERVICE RTE_LOGTYPE_USER3
 #define DP_VS_SVC_F_PERSISTENT      0x0001      /* peristent port */
 #define DP_VS_SVC_F_HASHED          0x0002      /* hashed entry */
+#define DP_VS_SVC_F_ONEPACKET       0x0004      /* one-packet scheduling */
 #define DP_VS_SVC_F_SYNPROXY        0x8000      /* synrpoxy flag */
 
 #define DP_VS_SVC_F_SIP_HASH        0x0100      /* sip hash target */

--- a/include/ipvs/service.h
+++ b/include/ipvs/service.h
@@ -84,6 +84,7 @@ struct dp_vs_service {
     uint32_t            num_laddrs;
 
     /* ... flags, timer ... */
+    uint32_t            proxy_protocol;
 } __rte_cache_aligned;
 
 

--- a/src/ipvs/ip_vs_conn.c
+++ b/src/ipvs/ip_vs_conn.c
@@ -864,6 +864,7 @@ struct dp_vs_conn *dp_vs_conn_new(struct rte_mbuf *mbuf,
         new->daddr  = dest->addr;
     new->dport  = rport;
     new->outwall = param->outwall;
+    new->proxy_protocol = param->proxy_protocol;
 
     /* neighbour confirm cache */
     if (AF_INET == tuplehash_in(new).af) {

--- a/src/ipvs/ip_vs_core.c
+++ b/src/ipvs/ip_vs_core.c
@@ -283,6 +283,7 @@ struct dp_vs_conn *dp_vs_schedule(struct dp_vs_service *svc,
     struct dp_vs_dest *dest;
     struct dp_vs_conn *conn;
     struct dp_vs_conn_param param;
+    uint32_t flags = 0;
 
     assert(svc && iph && mbuf);
     param.proxy_protocol = false;
@@ -339,10 +340,15 @@ struct dp_vs_conn *dp_vs_schedule(struct dp_vs_service *svc,
                               &iph->saddr, &iph->daddr,
                               ports[0], ports[1], 0, &param);
     }
-
     param.proxy_protocol = svc->proxy_protocol ? true : false;
-    conn = dp_vs_conn_new(mbuf, iph, &param, dest,
-            is_synproxy_on ? DPVS_CONN_F_SYNPROXY : 0);
+
+    if (is_synproxy_on) {
+        flags |= DPVS_CONN_F_SYNPROXY;
+    }
+    if (svc->flags & DP_VS_SVC_F_ONEPACKET && iph->proto == IPPROTO_UDP) {
+        flags |= DPVS_CONN_F_ONE_PACKET;
+    }
+    conn = dp_vs_conn_new(mbuf, iph, &param, dest, flags);
     if (!conn)
         return NULL;
 

--- a/src/ipvs/ip_vs_core.c
+++ b/src/ipvs/ip_vs_core.c
@@ -81,6 +81,7 @@ static struct dp_vs_conn *dp_vs_sched_persist(struct dp_vs_service *svc,
 #ifdef CONFIG_DPVS_IPVS_DEBUG
     char sbuf[64], dbuf[64], maskbuf[64];
 #endif
+    param.proxy_protocol = false;
 
     assert(svc && iph && mbuf);
 
@@ -186,6 +187,7 @@ static struct dp_vs_conn *dp_vs_snat_schedule(struct dp_vs_dest *dest,
     struct dp_vs_conn_param param;
     struct sockaddr_storage daddr, saddr;
     uint16_t _ports[2];
+    param.proxy_protocol = false;
 
     if (unlikely(iph->proto == IPPROTO_ICMP)) {
         struct icmphdr *ich, _icmph;
@@ -281,6 +283,7 @@ struct dp_vs_conn *dp_vs_schedule(struct dp_vs_service *svc,
     struct dp_vs_dest *dest;
     struct dp_vs_conn *conn;
     struct dp_vs_conn_param param;
+    param.proxy_protocol = false;
 
     assert(svc && iph && mbuf);
 
@@ -337,6 +340,7 @@ struct dp_vs_conn *dp_vs_schedule(struct dp_vs_service *svc,
                               ports[0], ports[1], 0, &param);
     }
 
+    param.proxy_protocol = svc->proxy_protocol ? true : false;
     conn = dp_vs_conn_new(mbuf, iph, &param, dest,
             is_synproxy_on ? DPVS_CONN_F_SYNPROXY : 0);
     if (!conn)

--- a/src/ipvs/ip_vs_proxy_protocol.c
+++ b/src/ipvs/ip_vs_proxy_protocol.c
@@ -1,0 +1,220 @@
+/*
+ * DPVS is a software load balancer (Virtual Server) based on DPDK.
+ *
+ * Copyright (C) 2017 iQIYI (www.iqiyi.com).
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+#include "ipvs/ipvs.h"
+#include "ipvs/proto_tcp.h"
+#include "ipv4.h"
+#include "ipv6.h"
+#include "parser/parser.h"
+#include "ipvs/proxy_protocol.h"
+
+static int dp_vs_fill_pphdr(int af, struct rte_mbuf *mbuf)
+{
+    int iphdrlen, thdrlen;
+    int pphdrlen, iptot_len;
+    int ploadlen;
+    void *iph = NULL, *niph = NULL;
+    struct tcphdr *th;
+    struct proxy_hdr_v2 *pphdr_ptr;
+
+    /* iphdr */
+    switch(af) {
+        case AF_INET6:
+            iph       = ip6_hdr(mbuf);
+            iphdrlen  = ip6_hdrlen(mbuf);
+            pphdrlen  = PROXY_PROTO_HDR_LEN_V6;
+            iptot_len = sizeof(struct ip6_hdr) +
+                        ntohs(((struct ip6_hdr *)iph)->ip6_plen);
+            break;
+        case AF_INET:
+            iph       = ip4_hdr(mbuf);
+            iphdrlen  = ip4_hdrlen(mbuf);
+            pphdrlen  = PROXY_PROTO_HDR_LEN_V4;
+            iptot_len = ntohs(((struct ipv4_hdr *)iph)->total_length);
+            break;
+        default:
+            return EDPVS_NOTSUPP;
+    }
+
+    /* thdr */
+    th = tcp_hdr(mbuf);
+    thdrlen = (th->doff) << 2;
+    ploadlen = iptot_len - iphdrlen - thdrlen;
+
+    /* reserve pphdr from headrom */
+    if (iptot_len > (iphdrlen + thdrlen) * 2) {
+        niph = (void *)rte_pktmbuf_prepend(mbuf, pphdrlen);
+        if (unlikely(!niph)) {
+            /* record log */
+            return EDPVS_FRAG;
+        }
+        /* mv iph and th forward */
+        memmove(niph, iph, iphdrlen + thdrlen);
+        th = (struct tcphdr *)((void *)th - pphdrlen);
+    } else {
+        unsigned char *ptr;
+
+        niph = iph;
+        if (unlikely(mbuf_may_pull(mbuf, mbuf->pkt_len) != 0)) {
+            /* record log */
+            return EDPVS_FRAG;
+        }
+
+        ptr = (void *)rte_pktmbuf_append(mbuf, pphdrlen);
+        if (unlikely(!ptr)) {
+            /* record log */
+            return EDPVS_FRAG;
+        }
+
+        /* mv iph and th forward */
+        memmove((void *)th + thdrlen + pphdrlen,
+                (void *)th + thdrlen,
+                ploadlen);
+    }
+
+    /* fill proxy protocol head v2 */
+    pphdr_ptr = (struct proxy_hdr_v2 *)((void *)th + thdrlen);
+    memcpy(pphdr_ptr->sig, PROXY_PROTO_V2_SIGNATURE , sizeof(PROXY_PROTO_V2_SIGNATURE ) - 1);
+    pphdr_ptr->ver = 2;     /* 2:v2 */
+    pphdr_ptr->cmd = 1;     /* 0:LOCAL, 1:PROXY */
+    pphdr_ptr->af  = (af == AF_INET ? 1 : 2); /* 0:AF_UNIX, 1:AF_INET, 2:AF_INET6, 3:AF_UNIX */
+    pphdr_ptr->proto = 1;   /* 0:UNSPEC, 1:STREAM, 2:DGRAM */ 
+    
+    if (af == AF_INET6) {
+        struct proxy_addr_ipv6 *ppaddr = (struct proxy_addr_ipv6 *)(pphdr_ptr + 1);
+        struct ip6_hdr *ip6h  = (struct ip6_hdr *)niph;
+
+        pphdr_ptr->addrlen    = htons(sizeof(struct proxy_addr_ipv6));
+        memcpy(ppaddr->src_addr, &ip6h->ip6_src, IPV6_ADDR_LEN_IN_BYTES);
+        memcpy(ppaddr->dst_addr, &ip6h->ip6_dst, IPV6_ADDR_LEN_IN_BYTES);
+        ppaddr->src_port      = th->th_sport;
+        ppaddr->dst_port      = th->th_dport;
+        /* update iph */
+        ((struct ip6_hdr *)niph)->ip6_plen =
+                    htons(ntohs(((struct ip6_hdr *)niph)->ip6_plen) + pphdrlen);
+    } else {
+        struct proxy_addr_ipv4 *ppaddr = (struct proxy_addr_ipv4 *)(pphdr_ptr + 1);
+        struct ipv4_hdr *ip4h = (struct ipv4_hdr *)niph;
+
+        pphdr_ptr->addrlen    = htons(sizeof(struct proxy_addr_ipv4));
+        ppaddr->src_addr      = ip4h->src_addr;
+        ppaddr->dst_addr      = ip4h->dst_addr;
+        ppaddr->src_port      = th->th_sport;
+        ppaddr->dst_port      = th->th_dport;
+        /* update iph */
+        ip4h->total_length = htons(ntohs(ip4h->total_length) + pphdrlen);
+    }
+
+    return EDPVS_OK;
+}
+
+int dp_vs_pphdr_inbound(struct rte_mbuf *mbuf,
+                        struct dp_vs_conn *conn)
+{
+    int err;
+    int af = conn->af;
+    int iphdrlen, thdrlen;
+    int pphdrlen, ploadlen, iptot_len;
+    uint16_t oldmss = 0;
+    void *iph = NULL;
+    struct tcphdr *th;
+
+    /* iphdr */
+    if (AF_INET6 == af) {
+        iph       = ip6_hdr(mbuf);
+        iphdrlen  = ip6_hdrlen(mbuf);
+        pphdrlen  = PROXY_PROTO_HDR_LEN_V6; 
+        iptot_len = sizeof(struct ip6_hdr) +
+                    ntohs(((struct ip6_hdr *)iph)->ip6_plen);
+    } else if (AF_INET == af) {
+        iph       = ip4_hdr(mbuf);
+        iphdrlen  = ip4_hdrlen(mbuf);
+        pphdrlen  = PROXY_PROTO_HDR_LEN_V4; 
+        iptot_len = ntohs(((struct ipv4_hdr *)iph)->total_length);
+    } else {
+        /* record log */
+        return EDPVS_NOTSUPP;
+    }
+
+    /* tcphdr */
+    th = tcp_hdr(mbuf);
+    thdrlen = (th->doff) << 2;
+    ploadlen = iptot_len - iphdrlen - thdrlen;
+
+    if (th->syn && !th->ack) {
+        if (ploadlen) {
+            /* drop syn packet with payload, eg:TFO */
+            return EDPVS_FRAG;
+        } else {
+            tcpopt_get_mss(af, mbuf, &oldmss);
+            /* update mss option, skip current packet */
+            tcpopt_update_mss(af, mbuf, oldmss - pphdrlen);
+            return EDPVS_OK;
+        }
+    }
+
+    if (ntohl(th->ack_seq) == conn->fnat_seq.fdata_seq
+            && !th->syn && !th->rst && !th->fin) {
+        /* add pphdr to first data packet with payload */
+        if (ploadlen) {
+            err = dp_vs_fill_pphdr(af, mbuf);
+            if (err != EDPVS_OK) {
+                RTE_LOG(WARNING, IPVS, "[%s:%d] fill_pphdr failed!\n", __func__, __LINE__);
+                return err;
+            }
+        }
+        return EDPVS_OK;
+    }
+
+    /* update seq in tcp header, checksum will be recal by hardware */
+    th->seq = htonl(ntohl(th->seq) + pphdrlen);
+    return EDPVS_OK;
+}
+
+int dp_vs_pphdr_outbound(struct rte_mbuf *mbuf,
+                         struct dp_vs_conn *conn)
+{
+    int af = conn->af;
+    int pphdrlen;
+    uint16_t oldmss;
+    struct tcphdr *th = tcp_hdr(mbuf);
+
+    switch(af) {
+        case AF_INET6:
+            pphdrlen = PROXY_PROTO_HDR_LEN_V6;
+            break;
+        case AF_INET:
+            pphdrlen = PROXY_PROTO_HDR_LEN_V4;
+            break;
+        default:
+            return EDPVS_NOTSUPP;
+    }
+
+    /* update mss option for syn packet */
+    if (th->syn && th->ack) {
+        tcpopt_get_mss(af, mbuf, &oldmss);
+        /* update mss option */
+        tcpopt_update_mss(af, mbuf, oldmss - pphdrlen);
+        return EDPVS_OK;
+    }
+
+    /* update ack_seq in tcp header */
+    th->ack_seq = htonl(ntohl(th->ack_seq) - pphdrlen);
+
+    return EDPVS_OK;
+}
+

--- a/src/ipvs/ip_vs_service.c
+++ b/src/ipvs/ip_vs_service.c
@@ -518,6 +518,7 @@ static int dp_vs_service_add(struct dp_vs_service_conf *u,
     svc->bps = u->bps;
     svc->limit_proportion = u->limit_proportion;
     svc->netmask = u->netmask;
+    svc->proxy_protocol = u->proxy_protocol;
     if (!is_empty_match(&u->match)) {
         svc->match = rte_zmalloc(NULL, sizeof(struct dp_vs_match),
                                  RTE_CACHE_LINE_SIZE);
@@ -590,6 +591,7 @@ static int dp_vs_service_edit(struct dp_vs_service *svc, struct dp_vs_service_co
     svc->netmask = u->netmask;
     svc->bps = u->bps;
     svc->limit_proportion = u->limit_proportion;
+    svc->proxy_protocol = u->proxy_protocol;
 
     old_sched = svc->scheduler;
     if (sched != old_sched) {
@@ -845,6 +847,7 @@ static int dp_vs_copy_usvc_compat(struct dp_vs_service_conf *conf,
     conf->netmask = user->netmask;
     conf->bps = user->bps;
     conf->limit_proportion = user->limit_proportion;
+    conf->proxy_protocol = user->proxy_protocol;
 
     if (user->flags & DP_VS_SVC_F_MATCH) {
         err = dp_vs_match_parse(user->srange, user->drange,

--- a/src/ipvs/ip_vs_xmit.c
+++ b/src/ipvs/ip_vs_xmit.c
@@ -29,6 +29,7 @@
 #include "ipvs/xmit.h"
 #include "ipvs/nat64.h"
 #include "parser/parser.h"
+#include "ipvs/proxy_protocol.h"
 
 static bool fast_xmit_close = false;
 static bool xmit_ttl = false;
@@ -696,8 +697,17 @@ int dp_vs_xmit_fnat(struct dp_vs_proto *proto,
                     struct dp_vs_conn *conn,
                     struct rte_mbuf *mbuf)
 {
+    int err;
     int af = conn->af;
     assert(af == AF_INET || af == AF_INET6);
+
+    /* add pphdr to first data packet when proxy_protocol switch is on */
+    if (conn->proxy_protocol) {
+        err = dp_vs_pphdr_inbound(mbuf, conn);
+        if (err < 0) {
+            goto notsupp;
+        }
+    }
 
     if (tuplehash_in(conn).af == AF_INET &&
         tuplehash_out(conn).af == AF_INET)
@@ -709,6 +719,7 @@ int dp_vs_xmit_fnat(struct dp_vs_proto *proto,
         tuplehash_out(conn).af == AF_INET)
         return __dp_vs_xmit_fnat64(proto, conn, mbuf);
 
+notsupp:
     rte_pktmbuf_free(mbuf);
     return EDPVS_NOTSUPP;
 }
@@ -1004,8 +1015,16 @@ int dp_vs_out_xmit_fnat(struct dp_vs_proto *proto,
                         struct dp_vs_conn *conn,
                         struct rte_mbuf *mbuf)
 {
+    int err;
     int af = conn->af;
     assert(af == AF_INET || af == AF_INET6);
+
+    if (conn->proxy_protocol) {
+        err = dp_vs_pphdr_outbound(mbuf, conn);
+        if (err < 0) {
+            goto notsupp;
+        }
+    }
 
     if (tuplehash_in(conn).af == AF_INET &&
         tuplehash_out(conn).af == AF_INET)
@@ -1017,6 +1036,7 @@ int dp_vs_out_xmit_fnat(struct dp_vs_proto *proto,
         tuplehash_out(conn).af == AF_INET)
         return __dp_vs_out_xmit_fnat46(proto, conn, mbuf);
 
+notsupp:
     rte_pktmbuf_free(mbuf);
     return EDPVS_NOTSUPP;
 }

--- a/tools/keepalived/keepalived/check/check_data.c
+++ b/tools/keepalived/keepalived/check/check_data.c
@@ -457,6 +457,7 @@ dump_vs(FILE *fp, const void *data)
 	conf_write(fp, "   alive = %d", vs->alive);
 	conf_write(fp, "   quorum_state_up = %d", vs->quorum_state_up);
 	conf_write(fp, "   reloaded = %d", vs->reloaded);
+	conf_write(fp, "   proxy_protocol = %d", vs->proxy_protocol);
 
 	dump_list(fp, vs->rs);
 }

--- a/tools/keepalived/keepalived/check/check_parser.c
+++ b/tools/keepalived/keepalived/check/check_parser.c
@@ -163,6 +163,8 @@ vs_handler(const vector_t *strvec)
 		return;
 
 	alloc_vs(strvec_slot(strvec, 1), vector_size(strvec) >= 3 ? strvec_slot(strvec, 2) : NULL);
+    virtual_server_t *vs = LIST_TAIL_DATA(check_data->vs);
+    vs->proxy_protocol = global_data->proxy_protocol;
 }
 static void
 vs_end_handler(void)
@@ -1100,6 +1102,13 @@ hash_target_handler(const vector_t *strvec)
 	}
 }
 
+static void
+proxy_protocol_handler(const vector_t *strvec)
+{
+	virtual_server_t *vs = LIST_TAIL_DATA(check_data->vs);
+	vs->proxy_protocol = 1;
+}
+
 void
 init_check_keywords(bool active)
 {
@@ -1169,6 +1178,7 @@ init_check_keywords(bool active)
 	install_keyword("oif", &oif_handler);
 	install_keyword("iif", &iif_handler);
 	install_keyword("hash_target", &hash_target_handler);
+	install_keyword("proxy_protocol", &proxy_protocol_handler);
 
 	/* Pool regression detection and handling. */
 	install_keyword("alpha", &vs_alpha_handler);

--- a/tools/keepalived/keepalived/check/ipvswrapper.c
+++ b/tools/keepalived/keepalived/check/ipvswrapper.c
@@ -771,6 +771,7 @@ ipvs_set_srule(int cmd, ipvs_service_t *srule, virtual_server_t *vs)
 		}
 	}
 
+    srule->user.proxy_protocol = vs->proxy_protocol;
 #ifdef _HAVE_PE_NAME_
 	strcpy(srule->pe_name, vs->pe_name);
 #endif

--- a/tools/keepalived/keepalived/check/libipvs.c
+++ b/tools/keepalived/keepalived/check/libipvs.c
@@ -64,6 +64,7 @@ typedef struct dp_vs_service_entry_app {
 	X->netmask          = Y->user.netmask; 			\
 	X->bps              = Y->user.bps; 			\
 	X->limit_proportion = Y->user.limit_proportion; 	\
+	X->proxy_protocol   = Y->user.proxy_protocol; 	    \
 	snprintf(X->sched_name, IP_VS_SCHEDNAME_MAXLEN, "%s", Y->user.sched_name); \
 	snprintf(X->srange, sizeof(X->srange), "%s", Y->user.srange); \
 	snprintf(X->drange, sizeof(X->drange), "%s", Y->user.drange); \

--- a/tools/keepalived/keepalived/core/global_data.c
+++ b/tools/keepalived/keepalived/core/global_data.c
@@ -269,6 +269,7 @@ init_global_data(data_t * data, data_t *prev_global_data, bool copy_unchangeable
 				data->smtp_helo_name = STRDUP(data->local_name);
 		}
 	}
+    data->proxy_protocol = 0;
 
 	/* Check that there aren't conflicts with the notify FIFOs */
 #ifdef _WITH_VRRP_
@@ -660,4 +661,5 @@ dump_global_data(FILE *fp, data_t * data)
 	if (global_data->log_unknown_vrids)
 		conf_write(fp, " log_unknown_vrids");
 #endif
+	conf_write(fp, " proxy_protocol %s", global_data->proxy_protocol ? "enabled" : "disabled");
 }

--- a/tools/keepalived/keepalived/core/global_parser.c
+++ b/tools/keepalived/keepalived/core/global_parser.c
@@ -1780,6 +1780,12 @@ random_seed_handler(const vector_t *strvec)
 	set_random_seed(val);
 }
 
+static void
+proxy_protocol_handler(const vector_t *strvec)
+{
+	global_data->proxy_protocol = 1;
+}
+
 void
 init_global_keywords(bool global_active)
 {
@@ -1958,4 +1964,5 @@ init_global_keywords(bool global_active)
 #endif
 	install_keyword("umask", &umask_handler);
 	install_keyword("random_seed", &random_seed_handler);
+	install_keyword("proxy_protocol", &proxy_protocol_handler);
 }

--- a/tools/keepalived/keepalived/include/check_api.h
+++ b/tools/keepalived/keepalived/include/check_api.h
@@ -35,6 +35,7 @@
 #include "check_data.h"
 #include "vector.h"
 #include "layer4.h"
+#include "conf/pphdr.h"
 
 /* Checkers structure definition */
 typedef struct _checker {

--- a/tools/keepalived/keepalived/include/check_data.h
+++ b/tools/keepalived/keepalived/include/check_data.h
@@ -246,6 +246,7 @@ typedef struct _virtual_server {
 	char 	*local_addr_gname; 	/*local ip address group name*/
 	char 	*blklst_addr_gname; 	/*black list ip group name*/	
 	char 	*vip_bind_dev; 		/*the interface name, vip bindto*/
+	uint32_t proxy_protocol;
 } virtual_server_t;
 
 /* Configuration data root */
@@ -303,6 +304,7 @@ static inline bool quorum_equal(const notify_script_t *quorum1,
                          (X)->conn_timeout            == (Y)->conn_timeout              &&\
                          (X)->bps                     == (Y)->bps                       &&\
                          (X)->limit_proportion        == (Y)->limit_proportion          &&\
+                         (X)->proxy_protocol          == (Y)->proxy_protocol            &&\
                          (((X)->vsgname && (Y)->vsgname &&                              \
                            !strcmp((X)->vsgname, (Y)->vsgname)) ||                      \
                           (!(X)->vsgname && !(Y)->vsgname))                             &&\

--- a/tools/keepalived/keepalived/include/global_data.h
+++ b/tools/keepalived/keepalived/include/global_data.h
@@ -268,6 +268,7 @@ typedef struct _data {
 	unsigned			vrrp_startup_delay;
 	bool				log_unknown_vrids;
 #endif
+	unsigned			proxy_protocol;
 } data_t;
 
 /* Global vars exported */

--- a/tools/keepalived/keepalived/include/ip_vs.h
+++ b/tools/keepalived/keepalived/include/ip_vs.h
@@ -168,6 +168,7 @@ struct ip_vs_service_user {
 	char		drange[256];
 	char		iifname[IFNAMSIZ];
 	char		oifname[IFNAMSIZ];
+    unsigned    proxy_protocol;
 };
 
 struct ip_vs_dest_user {
@@ -260,6 +261,7 @@ struct ip_vs_service_entry {
 	char			drange[256];
 	char			iifname[IFNAMSIZ];
 	char			oifname[IFNAMSIZ];
+    unsigned        proxy_protocol;
 };
 
 struct ip_vs_dest_entry {


### PR DESCRIPTION
'proxy_protocol' keyword should be configured in 'keepalived.conf', and virtual_server should be configured with FNAT for TCP, the detailed configurations are as follows:
1. 'global_defs': proxy_protocol_v2 support is available for all virtual_server when 'proxy_protocol' is configured in 'global_defs' block:
global_defs {
        ......
        proxy_protocol
        ......
}

2. 'virtual_server': proxy_protocol_v2 support is available for the given virtual_server when 'proxy_protocol' is configured in 'virtual_server' block:
virtual_server ip_addr port {
        ........
        lb_kind FNAT
        protocol TCP
        proxy_protocol
        ........
}