### PR TITLE
kmod/toa: Fix compilation on newer systems (e.g., CentOS 7.7+)

### DIFF
--- a/kmod/toa/toa.h
+++ b/kmod/toa/toa.h
@@ -20,6 +20,9 @@
 #include <net/ipv6.h>
 #include <net/transp_v6.h>
 #include <net/sock.h>
+#ifdef TOA_NAT64_ENABLE
+#  include <linux/netfilter.h>  /* for 'struct nf_sockopt_ops' */
+#endif
 
 #define TOA_VERSION "2.0.0.0"
 


### PR DESCRIPTION
On newer systems (such as CentoOS 7.7+), the `<linux/netfilter.h>`
header must be explicitly included to obtain the declaration of
`struct nf_sockopt_ops`.  Otherwise, the toa modules fail to compile.

This fixes issue #504.