### PR TITLE
keepalived: fix keepalived compile error with kernel 3.11 and above

### DIFF
--- a/patch/ubuntu_keepalived.patch
+++ b/patch/ubuntu_keepalived.patch
@@ -19,7 +19,7 @@
 -      IPV4_DEVCONF=No
 -      break
 -    ],
--    [[#include <linux/ip.h>]])
+-    [[#include <uapi/linux/ip.h>]])
 -  if test $IPV4_DEVCONF = Yes; then
 -    AC_DEFINE([_HAVE_IPV4_DEVCONF_], [ 1 ], [Define to 1 if have IPv4 netlink device configuration])
 -    add_system_opt([IPV4_DEVCONF])

--- a/tools/keepalived/configure.ac
+++ b/tools/keepalived/configure.ac
@@ -1085,7 +1085,7 @@ if test .$enable_vrrp != .no; then
       IPV4_DEVCONF=No
       break
     ],
-    [[#include <linux/ip.h>]])
+    [[#include <uapi/linux/ip.h>]])
   if test $IPV4_DEVCONF = Yes; then
     AC_DEFINE([_HAVE_IPV4_DEVCONF_], [ 1 ], [Define to 1 if have IPv4 netlink device configuration])
     add_system_opt([IPV4_DEVCONF])


### PR DESCRIPTION

In kernel versions below 3.11, IPV4_DEVCONF_ARP_IGNORE is defined in the include/linux/inetdevice.h file, 
but in kernel 3.11 and above, it is defined in the include/uapi/linux/ip.h file;