### PR TITLE
ipvsadm: fix ipvsadm -ln show null error 

### DIFF
--- a/tools/ipvsadm/Makefile
+++ b/tools/ipvsadm/Makefile
@@ -84,7 +84,7 @@ endif
 
 OBJS		= ipvsadm.o config_stream.o dynamic_array.o
 LIBS		= $(POPT_LIB) -lnuma
-DEFINES		= -DVERSION=\"$(VERSION)\" -DSCHEDULERS=\"$(SCHEDULERS)\" \
+DEFINES		= -D_IPVSADM_VERSION=\"$(VERSION)\" -DSCHEDULERS=\"$(SCHEDULERS)\" \
 		  -DPE_LIST=\"$(PE_LIST)\" $(POPT_DEFINE)
 DEFINES		+= $(shell if [ ! -f ../ip_vs.h ]; then	\
 		     echo "-DHAVE_NET_IP_VS_H"; fi;)

--- a/tools/ipvsadm/ipvsadm.c
+++ b/tools/ipvsadm/ipvsadm.c
@@ -91,6 +91,8 @@
  */
 
 #undef __KERNEL__	/* Makefile lazyness ;) */
+#include "../keepalived/lib/config.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <netdb.h>
@@ -117,7 +119,7 @@
 #include "config_stream.h"
 #include "../keepalived/keepalived/include/libipvs.h"
 
-#define IPVSADM_VERSION_NO	"v" VERSION
+#define IPVSADM_VERSION_NO	"v" _IPVSADM_VERSION
 #define IPVSADM_VERSION_DATE	"2008/5/15"
 #define IPVSADM_VERSION		IPVSADM_VERSION_NO " " IPVSADM_VERSION_DATE
 
@@ -1984,10 +1986,17 @@ print_service_entry(ipvs_service_entry_t *se, unsigned int format, lcoreid_t cid
 			print_largenum(e->stats.outbytes, format);
 			printf("\n");
 		} else if (format & FMT_RATE) {
+#ifdef _WITH_LVS_64BIT_STATS_
+			printf("  -> %-28s %8llu %8llu %8llu", dname,
+			       e->stats.cps,
+			       e->stats.inpps,
+			       e->stats.outpps);
+#else
 			printf("  -> %-28s %8u %8u %8u", dname,
 			       e->stats.cps,
 			       e->stats.inpps,
 			       e->stats.outpps);
+#endif
 			print_largenum(e->stats.inbps, format);
 			print_largenum(e->stats.outbps, format);
 			printf("\n");

--- a/tools/keepalived/keepalived/check/libipvs.c
+++ b/tools/keepalived/keepalived/check/libipvs.c
@@ -112,8 +112,7 @@ typedef struct dp_vs_service_entry_app {
 	X->user.l_threshold      = Y->min_conn;			\
 	X->user.activeconns      = Y->actconns;			\
 	X->user.inactconns       = Y->inactconns;			\
-	X->user.persistconns     = Y->persistconns;			\
-	memcpy(&X->stats, &Y->stats, sizeof(X->stats));}
+	X->user.persistconns     = Y->persistconns;}
 
 static void ipvs_service_entry_2_user(const ipvs_service_entry_t *entry, ipvs_service_t *rule)
 {
@@ -575,6 +574,23 @@ struct ip_vs_get_services_app *ipvs_get_services(lcoreid_t cid)
 #ifdef _WITH_SNMP_CHECKER_
 #endif	/* _WITH_SNMP_CHECKER_ */
 
+static int ipvs_parse_stats(ip_vs_stats_t * ipvs_stats, struct dp_vs_stats* dpvs_stats)
+{
+    ipvs_stats->conns = dpvs_stats->conns;
+    ipvs_stats->inpkts = dpvs_stats->inpkts;
+    ipvs_stats->inbytes = dpvs_stats->inbytes;
+    ipvs_stats->outpkts = dpvs_stats->outpkts;
+    ipvs_stats->outbytes = dpvs_stats->outbytes;
+
+    ipvs_stats->cps = dpvs_stats->cps;
+    ipvs_stats->inpps = dpvs_stats->inpps;
+    ipvs_stats->inbps = dpvs_stats->inbps;
+    ipvs_stats->outpps = dpvs_stats->outpps;
+    ipvs_stats->outbps = dpvs_stats->outbps;
+
+    return 0;
+}
+
 struct ip_vs_get_dests_app *ipvs_get_dests(ipvs_service_entry_t *svc, lcoreid_t cid)
 {
 	struct ip_vs_get_dests_app *d;
@@ -633,6 +649,7 @@ struct ip_vs_get_dests_app *ipvs_get_dests(ipvs_service_entry_t *svc, lcoreid_t 
 		ipvs_entry = &d->user.entrytable[i];
 		dpvs_entry = &dpvs_dests_rcv->entrytable[i];
 		DPRS_2_IPRS(ipvs_entry, dpvs_entry);
+		ipvs_parse_stats(&ipvs_entry->stats, &dpvs_entry->stats);
 		if (d->user.entrytable[i].af == AF_INET)
 			d->user.entrytable[i].user.__addr_v4 = d->user.entrytable[i].nf_addr.ip;
 	}


### PR DESCRIPTION
In kernel 4.1 and above, the macro  _WITH_LVS_64BIT_STATS_  will be defined in config.h.
The function ipvs_get_services is in libipvs.c which includes config.h, so the member stats in struct ip_vs_service_entry_app will be the type of struct ip_vs_stats64.

While the function list_all is in  ipvsadm.c which does not include config.h, so the member stats will be the type of struct ip_vs_stats_user.

The different size of member stats in struct ip_vs_service_entry_app will affect the value of member af and nf_affr in struct ip_vs_service_entry_app.