### PR TITLE
ipvsadm: fix change conhash target error

### DIFF
--- a/tools/keepalived/keepalived/check/libipvs.c
+++ b/tools/keepalived/keepalived/check/libipvs.c
@@ -243,6 +243,8 @@ int ipvs_update_service_by_options(ipvs_service_t *svc, unsigned int options)
 	}
 
 	if (options & OPT_HASHTAG) {
+		app.user.flags &= ~ IP_VS_SVC_F_QID_HASH;
+		app.user.flags &= ~ IP_VS_SVC_F_SIP_HASH;
 		if (svc->user.flags & IP_VS_SVC_F_SIP_HASH) {
 			app.user.flags |= IP_VS_SVC_F_SIP_HASH;
 		} else if (svc->user.flags & IP_VS_SVC_F_QID_HASH) {


### PR DESCRIPTION

If the hash factor of the conhash scheduling algorithm of vs is sip, we want to change the hash factor to qid through ipvsadm -E -u xxx -s conhash -Y qid. we will find that the vs will have two hash factors, sip and qid through ipvsadm -ln.