### PR TITLE
ipvsadm: fix ipvsadm -ln show null error

### DIFF
--- a/tools/keepalived/keepalived/include/check_data.h
+++ b/tools/keepalived/keepalived/include/check_data.h
@@ -98,11 +98,7 @@ typedef struct _real_server {
 	uint32_t			activeconns;	/* active connections */
 	uint32_t			inactconns;	/* inactive connections */
 	uint32_t			persistconns;	/* persistent connections */
-#ifndef _WITH_LVS_64BIT_STATS_
 	struct ip_vs_stats_user		stats;
-#else
-	struct ip_vs_stats64		stats;
-#endif
 #endif
 #ifdef _WITH_BFD_
 	list				tracked_bfds;	/* list of bfd_checker_t */
@@ -232,11 +228,7 @@ typedef struct _virtual_server {
 #if defined(_WITH_SNMP_CHECKER_) && defined(_WITH_LVS_)
 	/* Statistics */
 	time_t				lastupdated;
-#ifndef _WITH_LVS_64BIT_STATS_
 	struct ip_vs_stats_user		stats;
-#else
-	struct ip_vs_stats64		stats;
-#endif
 #endif
 	char 	srange[256];
 	char 	drange[256];

--- a/tools/keepalived/keepalived/include/ip_vs.h
+++ b/tools/keepalived/keepalived/include/ip_vs.h
@@ -507,24 +507,7 @@ enum {
 //
 /////////////////////////////////////////////////////////////////////////////////////////
 
-#ifdef _WITH_LVS_64BIT_STATS_
-struct ip_vs_stats64 {
-	__u64	conns;		/* connections scheduled */
-	__u64	inpkts;		/* incoming packets */
-	__u64	outpkts;	/* outgoing packets */
-	__u64	inbytes;	/* incoming bytes */
-	__u64	outbytes;	/* outgoing bytes */
-
-	__u64	cps;		/* current connection rate */
-	__u64	inpps;		/* current in packet rate */
-	__u64	outpps;		/* current out packet rate */
-	__u64	inbps;		/* current in byte rate */
-	__u64	outbps;		/* current out byte rate */
-};
-typedef struct ip_vs_stats64 ip_vs_stats_t;
-#else
 typedef struct ip_vs_stats_user ip_vs_stats_t;
-#endif
 
 struct ip_vs_service_app {
 	struct ip_vs_service_user user;


### PR DESCRIPTION
In kernel 4.1 and above, the macro WITH_LVS_64BIT_STATS will be defined in config.h.
The function ipvs_get_services is in libipvs.c which includes config.h, so the member stats in struct ip_vs_service_entry_app will be the type of struct ip_vs_stats64.

While the function list_all is in ipvsadm.c which does not include config.h, so the member stats will be the type of struct ip_vs_stats_user.

The different size of member stats in struct ip_vs_service_entry_app will affect the value of member af and nf_affr in struct ip_vs_service_entry_app.