### PR TITLE
show dpvs's ip in traceroute path

### DIFF
--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -533,7 +533,7 @@ int ipv4_xmit(struct rte_mbuf *mbuf, const struct flow4 *fl4)
     struct route_entry *rt;
     struct ipv4_hdr *iph;
 
-    if (!mbuf || !fl4 || fl4->fl4_saddr.s_addr == htonl(INADDR_ANY)) {
+    if (!mbuf || !fl4) {
         if (mbuf)
             rte_pktmbuf_free(mbuf);
         return EDPVS_INVAL;


### PR DESCRIPTION
when `fl4->fl4_saddr.s_addr == htonl(INADDR_ANY) ` ,source ip should be selected after route lookup. 