### PR TITLE
fix the dest max conn bug

### DIFF
--- a/src/ipvs/ip_vs_service.c
+++ b/src/ipvs/ip_vs_service.c
@@ -1049,6 +1049,8 @@ static int dp_vs_dests_copy_percore_stats(struct dp_vs_get_dests *master_dests,
     if (master_dests->num_dests != slave_dests->num_dests)
         return EDPVS_INVAL;
     for (i = 0; i < master_dests->num_dests; i++) {
+        master_dests->entrytable[i].max_conn += slave_dests->entrytable[i].max_conn;
+        master_dests->entrytable[i].min_conn += slave_dests->entrytable[i].min_conn;
         master_dests->entrytable[i].actconns += slave_dests->entrytable[i].actconns;
         master_dests->entrytable[i].inactconns += slave_dests->entrytable[i].inactconns;
         master_dests->entrytable[i].persistconns += slave_dests->entrytable[i].persistconns;

--- a/tools/keepalived/keepalived/check/ipwrapper.c
+++ b/tools/keepalived/keepalived/check/ipwrapper.c
@@ -53,11 +53,13 @@ vsge_iseq(const virtual_server_group_entry_t *vsge_a, const virtual_server_group
 	return true;
 }
 
+#if 0
 static bool __attribute((pure))
 rs_iseq(const real_server_t *rs_a, const real_server_t *rs_b)
 {
 	return sockstorage_equal(&rs_a->addr, &rs_b->addr);
 }
+#endif
 
 /* Returns the sum of all alive RS weight in a virtual server. */
 static unsigned long __attribute__ ((pure))
@@ -830,7 +832,7 @@ rs_exist(real_server_t * old_rs, list l)
 		return NULL;
 
 	LIST_FOREACH(l, rs, e) {
-		if (rs_iseq(rs, old_rs))
+		if (RS_ISEQ(rs, old_rs))
 			return rs;
 	}
 
@@ -980,7 +982,7 @@ clear_diff_s_srv(virtual_server_t *old_vs, real_server_t *new_rs)
 	if (!old_rs)
 		return;
 
-	if (new_rs && rs_iseq(old_rs, new_rs)) {
+	if (new_rs && RS_ISEQ(old_rs, new_rs)) {
 		/* which fields are really used on s_svr? */
 		new_rs->alive = old_rs->alive;
 		new_rs->set = old_rs->set;

--- a/tools/keepalived/keepalived/include/check_data.h
+++ b/tools/keepalived/keepalived/include/check_data.h
@@ -309,6 +309,11 @@ static inline bool quorum_equal(const notify_script_t *quorum1,
                          !strcmp((X)->iifname, (Y)->iifname)                            &&\
                          !strcmp((X)->oifname, (Y)->oifname))
 
+#define RS_ISEQ(X,Y)	(sockstorage_equal(&(X)->addr,&(Y)->addr) &&	\
+                            (X)->iweight   == (Y)->iweight) &&    \
+                            (X)->l_threshold == (Y)->l_threshold &&   \
+                            (X)->u_threshold == (Y)->u_threshold
+
 #ifndef IP_VS_SVC_F_SCHED_MH_PORT
 #define IP_VS_SVC_F_SCHED_MH_PORT IP_VS_SVC_F_SCHED_SH_PORT
 #endif


### PR DESCRIPTION
Two questions:
1) the max_conn of  dest should be based on the whole machine, not based on the lcore;
2) Changing the uthreshold of rs in keepalived.conf does not take effect;