### PR TITLE
kmod/toa: fix is_ro_addr()

### DIFF
--- a/kmod/toa/toa.c
+++ b/kmod/toa/toa.c
@@ -96,11 +96,11 @@ struct toa_stats_entry toa_stats[] = {
 unsigned int is_ro_addr(unsigned long addr)
 {
     unsigned int level;
-    unsigned int ro_enable = 0;
+    unsigned int ro_enable = 1;
     pte_t *pte = lookup_address(addr, &level);
-    if (pte->pte &~ _PAGE_RW)
+    if (pte->pte & _PAGE_RW)
     {
-            ro_enable = 1;
+            ro_enable = 0;
     }
     
     return ro_enable;
@@ -111,7 +111,8 @@ void set_addr_rw(unsigned long addr)
     unsigned int level;
     pte_t *pte = lookup_address(addr, &level);
 
-    if (pte->pte &~ _PAGE_RW) pte->pte |= _PAGE_RW;
+    pte->pte |= _PAGE_RW;
+    smp_wmb();
 }
 
 void set_addr_ro(unsigned long addr)
@@ -119,7 +120,7 @@ void set_addr_ro(unsigned long addr)
     unsigned int level;
     pte_t *pte = lookup_address(addr, &level);
 
-    pte->pte = pte->pte &~_PAGE_RW;
+    pte->pte &= ~_PAGE_RW;
 }
 
 DEFINE_TOA_STAT(struct toa_stat_mib, ext_stats);


### PR DESCRIPTION
#484 by @goecho was trying to fix crash problem on some kernel versions. The new function is_ro_addr() is used to check the `address` is `ro` or `rw`.

but the condition seems weired:
```
if (pte->pte &~ _PAGE_RW) {
  ro_enable = 1;
}
```

`pte->pte &~ _PAGE_RW` means there are some other flags being set, no matter RW flags is set or not.