### PR TITLE
Sometimes RS can't get client ip

### DIFF
--- a/src/ipvs/ip_vs_proto_tcp.c
+++ b/src/ipvs/ip_vs_proto_tcp.c
@@ -713,7 +713,7 @@ static int tcp_fnat_in_handler(struct dp_vs_proto *proto,
 
     /* add toa to first data packet */
     if (ntohl(th->ack_seq) == conn->fnat_seq.fdata_seq
-            && !th->syn && !th->rst && !th->fin)
+            && !th->syn && !th->rst /*&& !th->fin*/)
         tcp_in_add_toa(conn, mbuf, th);
 
     tcp_in_adjust_seq(conn, th);


### PR DESCRIPTION
(1): The connection only have one data to send.
(2): The data packet carry the fin flag.
when a connection satisfies the two conditions, it will can't add the toa option to the packet, then the RS will can't get the client IP. 
The original code：(in function tcp_fnat_in_handler)
/* add toa to first data packet */
    if (ntohl(th->ack_seq) == conn->fnat_seq.fdata_seq
            && !th->syn && !th->rst /*&& !th->fin*/)
        tcp_in_add_toa(conn, mbuf, th);
We should delete the check for th->fin.

This problem has been dicussed in the WeChat group named "DPVS dicussion group", then we also discussed that the toa option added in the tcp syn packet will not be used in the RS.
 
In production environment，I has captured the tcp stream which satisfies the two conditions, and than the nginx in RS can't get the clientip.

And I has used the RAW socket to simulate the conditions， the packet which satisfies the two conditions will can't carry the toa option to the RS.