### PR TITLE
fix: UDP checksum not correct using ipo UOA with checksum offloading disabled

### DIFF
--- a/include/ipv4.h
+++ b/include/ipv4.h
@@ -187,12 +187,15 @@ static inline uint16_t ip4_udptcp_cksum(struct ipv4_hdr *iph, const void *l4_hdr
 {
     uint16_t csum;
     uint16_t total_length = iph->total_length;
+    uint8_t version_ihl = iph->version_ihl;
 
     iph->total_length = htons(ntohs(total_length) -
             ((iph->version_ihl & 0xf) << 2) + sizeof(struct ipv4_hdr));
+    iph->version_ihl = (version_ihl & 0xf0) | (sizeof(struct ipv4_hdr) >> 2);
     csum = rte_ipv4_udptcp_cksum(iph, l4_hdr);
 
     iph->total_length = total_length;
+    iph->version_ihl = version_ihl;
     return csum;
 }
 


### PR DESCRIPTION
If UOA mode is set to `ipo` (use IP option) and UDP checksum offloading is disabled, the UDP checksum generated by DPVS is not correct.

For DPDK newer than 17.11.10, implementation for `rte_ipv4_udptcp_cksum()` has changed, where `l4_len` depends on both `ipv4_hdr->total_length` and `(ipv4_hdr->version_ihl & 0xf)`:
```
static inline uint16_t
rte_ipv4_udptcp_cksum(const struct ipv4_hdr *ipv4_hdr, const void *l4_hdr)
{
	// ...
	l3_len = rte_be_to_cpu_16(ipv4_hdr->total_length);
	l4_len = l3_len - (ipv4_hdr->version_ihl & 0xf) * 4;
	if (l4_len < 0)
		return 0;
	// ...
}
```

Thus, we need to mock both `iph->total_length` and `iph->version_ihl` before passing packet data to `rte_ipv4_udptcp_cksum()`.