### PR TITLE
IPVS: fix ipvs rr/wrr/wlc problem of uneven load distribution across …

### DIFF
--- a/include/ipvs/sched.h
+++ b/include/ipvs/sched.h
@@ -27,7 +27,6 @@ struct dp_vs_iphdr;
 struct dp_vs_scheduler {
     struct list_head    n_list;
     char                *name;
-//    rte_atomic32_t      refcnt;
 
     struct dp_vs_dest *
         (*schedule)(struct dp_vs_service *svc,
@@ -51,6 +50,8 @@ int dp_vs_bind_scheduler(struct dp_vs_service *svc,
 int dp_vs_unbind_scheduler(struct dp_vs_service *svc);
 
 int dp_vs_gcd_weight(struct dp_vs_service *svc);
+
+struct list_head * dp_vs_sched_first_dest(const struct dp_vs_service *svc);
 
 void dp_vs_scheduler_put(struct dp_vs_scheduler *scheduler);
 

--- a/src/ipvs/ip_vs_rr.c
+++ b/src/ipvs/ip_vs_rr.c
@@ -20,15 +20,15 @@
 
 static int dp_vs_rr_init_svc(struct dp_vs_service *svc)
 {
-    svc->sched_data = &svc->dests;
+    svc->sched_data = dp_vs_sched_first_dest(svc);
+
     return EDPVS_OK;
 }
 
 static int dp_vs_rr_update_svc(struct dp_vs_service *svc,
         struct dp_vs_dest *dest __rte_unused, sockoptid_t opt __rte_unused)
 {
-    svc->sched_data = &svc->dests;
-    return EDPVS_OK;
+    return dp_vs_rr_init_svc(svc);
 }
 
 /*
@@ -68,7 +68,6 @@ out:
 
 static struct dp_vs_scheduler dp_vs_rr_scheduler = {
     .name = "rr",       /* name */
-//    .refcnt = ATOMIC_INIT(0),
     .n_list = LIST_HEAD_INIT(dp_vs_rr_scheduler.n_list),
     .init_service = dp_vs_rr_init_svc,
     .update_service = dp_vs_rr_update_svc,

--- a/src/ipvs/ip_vs_wrr.c
+++ b/src/ipvs/ip_vs_wrr.c
@@ -54,7 +54,7 @@ static int dp_vs_wrr_init_svc(struct dp_vs_service *svc)
     if (mark == NULL) {
         return EDPVS_NOMEM;
     }
-    mark->cl = &svc->dests;
+    mark->cl = dp_vs_sched_first_dest(svc);
     mark->cw = 0;
     mark->mw = dp_vs_wrr_max_weight(svc);
     mark->di = dp_vs_gcd_weight(svc);
@@ -78,7 +78,7 @@ static int dp_vs_wrr_update_svc(struct dp_vs_service *svc,
 {
     struct dp_vs_wrr_mark *mark = svc->sched_data;
 
-    mark->cl = &svc->dests;
+    mark->cl = dp_vs_sched_first_dest(svc);
     mark->mw = dp_vs_wrr_max_weight(svc);
     mark->di = dp_vs_gcd_weight(svc);
     if (mark->cw > mark->mw)


### PR DESCRIPTION
…dests.

 Different workers should start schedule algorith from the dests that are
 evenly distributed across the whole dest list. It can avoid the clustering
 of connections across dests on the early phase after the service setup,
 especially for such scheduling methods as rr/wrr/wlc.

Signed-off-by: ywc689 <ywc689@163.com>