### PR TITLE
correct README.md guide for dpvs 1.9.0 build failed by exporting erro…

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ mkdir dpdkbuild               # user desired build folder
 $ meson -Denable_kmods=true -Dprefix=dpdklib dpdkbuild
 $ ninja -C dpdkbuild
 $ cd dpdkbuild; ninja install
-$ export PKG_CONFIG_PATH=$(pwd)/../dpdklib/lib64/pkgconfig/libdpdk.pc
+$ export PKG_CONFIG_PATH=$(pwd)/../dpdklib/lib64/pkgconfig/
 ```
 
 > Tips: You can use script [dpdk-build.sh](./scripts/dpdk-build.sh) to facilitate dpdk build. Run `dpdk-build.sh -h` for the usage of the script.
@@ -146,7 +146,7 @@ $ ./usertools/dpdk-devbind.py -b uio_pci_generic 0000:06:00.0
 It's simple, just set `PKG_CONFIG_PATH` and build it.
 
 ```bash
-$ export PKG_CONFIG_PATH=<path-of-libdpdk.pc>  # normally located at dpdklib/lib64/pkgconfig/libdpdk.pc
+$ export PKG_CONFIG_PATH=<path-of-libdpdk.pc>  # normally located at dpdklib/lib64/pkgconfig/
 $ cd <path-of-dpvs>
 
 $ make              # or "make -j" to speed up


### PR DESCRIPTION
…r environment variable PKG_CONFIG_PATH

Signed-off-by: linjianying <linjianying.dev@gmail.com>