### PR TITLE
bugfix: dpdk-pdump can't use 'device_id=net_bondingX'

### DIFF
--- a/src/netif.c
+++ b/src/netif.c
@@ -3982,7 +3982,7 @@ static int obtain_dpdk_bond_name(char *dst, const char *ori, size_t size)
      * DPDK need bonding device name start with "net_bonding"
      * to match the driver.
      */
-    snprintf(dst, size, "net_bonding%u\n", num);
+    snprintf(dst, size, "net_bonding%u", num);
 
     return EDPVS_OK;
 }


### PR DESCRIPTION
[root@localhost pdump]# dpdk-pdump -- --pdump 'device_id=net_bonding0,queue=*,rx-dev=/root/pdump/pcap
/capture.pcap,tx-dev=/root/pdump/pcap/capture.pcap'
EAL: Detected 32 lcore(s)
EAL: Detected 2 NUMA nodes
EAL: Multi-process socket /var/run/dpdk/rte/mp_socket_157010_2fd9063deca7c
EAL: Probing VFIO support...
EAL: PCI device 0000:5e:00.0 on NUMA socket 0
EAL:   probe driver: 8086:1572 net_i40e
EAL: PCI device 0000:5e:00.1 on NUMA socket 0
EAL:   probe driver: 8086:1572 net_i40e
Device 0000:5e:00.1 is not driven by the primary process
EAL: secondary process attach failed, ethdev doesn't existEAL: Requested device 0000:5e:00.1 cannot be used
EAL: PCI device 0000:61:00.0 on NUMA socket 0
EAL:   probe driver: 8086:37d0 net_i40e
Device 0000:61:00.0 is not driven by the primary process
EAL: secondary process attach failed, ethdev doesn't existEAL: Requested device 0000:61:00.0 cannot be used
EAL: PCI device 0000:61:00.1 on NUMA socket 0
EAL:   probe driver: 8086:37d0 net_i40e
EAL: PCI device 0000:61:00.2 on NUMA socket 0
EAL:   probe driver: 8086:37d1 net_i40e
EAL: PCI device 0000:61:00.3 on NUMA socket 0
EAL:   probe driver: 8086:37d1 net_i40e
Port 3 MAC: 02 70 63 61 70 00
^C

Signal 2 received, preparing to exit...
##### PDUMP DEBUG STATS #####
 -packets dequeued:                     618
 -packets transmitted to vdev:          618