### PR TITLE
keepalived: fix keepalived exiting while reloading

### DIFF
--- a/tools/keepalived/lib/notify.c
+++ b/tools/keepalived/lib/notify.c
@@ -462,6 +462,8 @@ script_killall(thread_master_t *m, int signo, bool requeue)
 
 	rb_for_each_entry_cached(thread, &m->child, n) {
 		c_pgid = getpgid(thread->u.c.pid);
+		if (c_pgid <= 0)
+			continue;
 		if (c_pgid != p_pgid)
 			kill(-c_pgid, signo);
 		else {


### PR DESCRIPTION
getpgid may return -1 or 0;
reutrn -1: kill(1, SIGTERM), send signal TERM to systemd.
return 0: kill(0, SIGTERM), send signal to keepalived master and keepalive checker, which cause keepalive exit.

(1) getpgid 
pid_t getpgid(pid_t pid);
 getpgid(),  return a process group on success. 
 On error, -1 is returned, and errno is set appropriately.
return 0 for parameter pid specify a kernel process.

(2) kill
int kill(pid_t pid, int sig);
DESCRIPTION:
If pid equals 0, then sig is sent to every process in the process group of the calling process.

(3)Steps to reproduce
3.1> Configure a large number of rs that use misc for health check
3.2> while true; do  kill -HUP `cat /var/run/keepalived.pid`; sleep 20; done
Note: 
In order to increase the probability of conflict between the pid of the kernel process and the pid of the previous misc process, the value of pid_max can be reduced.
eg: sysctl -w kernel.pid_max=10000

