### PR TITLE
modify bug: SNAT mode, ipvsadm displaying and editing the SVC will fail.

### DIFF
--- a/tools/ipvsadm/ipvsadm.c
+++ b/tools/ipvsadm/ipvsadm.c
@@ -21,7 +21,7 @@
  *        Wensong Zhang       :   added the long options
  *        Wensong Zhang       :   added the hostname and portname input
  *        Wensong Zhang       :   added the hostname and portname output
- *        Lars Marowsky-Brée  :   added persistence granularity support
+ *        Lars Marowsky-BrÃ©e  :   added persistence granularity support
  *        Julian Anastasov    :   fixed the (null) print for unknown services
  *        Wensong Zhang       :   added the port_to_anyname function
  *        Horms               :   added option to read commands from stdin
@@ -1379,6 +1379,8 @@ static int parse_match_snat(const char *buf, ipvs_service_t *svc)
     int r;
     bool range = false;
     bool af = false;
+    struct inet_addr_range ip_range;
+    int ip_af = 0;
 
     snprintf(params, sizeof(params), "%s", buf);
 
@@ -1414,9 +1416,17 @@ static int parse_match_snat(const char *buf, ipvs_service_t *svc)
         } else if (strcmp(key, "src-range") == 0) {
             range = true;
             snprintf(svc->user.srange, sizeof(svc->user.srange), "%s", val);
+            if (svc->af == 0) {
+                inet_addr_range_parse(svc->user.srange, &ip_range, &ip_af);
+                svc->af = ip_af;
+            }
         } else if (strcmp(key, "dst-range") == 0) {
             range = true;
             snprintf(svc->user.drange, sizeof(svc->user.drange), "%s", val);
+            if (svc->af == 0) {
+                inet_addr_range_parse(svc->user.drange, &ip_range, &ip_af);
+                svc->af = ip_af;
+            }
         } else if (strcmp(key, "iif") == 0) {
             snprintf(svc->user.iifname, sizeof(svc->user.iifname), "%s", val);
         } else if (strcmp(key, "oif") == 0) {

--- a/tools/keepalived/keepalived/check/libipvs.c
+++ b/tools/keepalived/keepalived/check/libipvs.c
@@ -132,7 +132,7 @@ static void ipvs_service_entry_2_user(const ipvs_service_entry_t *entry, ipvs_se
 	strcpy(rule->user.srange, entry->user.srange);
 	strcpy(rule->user.drange, entry->user.drange);
 	strcpy(rule->user.iifname, entry->user.iifname);
-	strcpy(rule->user.iifname, entry->user.iifname);
+	strcpy(rule->user.oifname, entry->user.oifname);
 }
 
 struct ip_vs_getinfo g_ipvs_info;
@@ -690,7 +690,7 @@ ipvs_get_service(ipvs_service_t *hint, lcoreid_t cid)
 	ipvs_service_entry_t *svc;
 	size_t len, len_rcv;
 	dpvs_service_entry_t dpvs_svc, *dpvs_svc_rcv;
-	struct dp_vs_service_user dpvs_app, *dpvs_app_ptr;
+	struct dp_vs_service_entry *dpvs_svc_entry;
 
 	ipvs_func = ipvs_get_service;
 
@@ -704,10 +704,8 @@ ipvs_get_service(ipvs_service_t *hint, lcoreid_t cid)
 	len_rcv = sizeof(*dpvs_svc_rcv);
 	memset(&dpvs_svc, 0, len);
 
-	dpvs_app_ptr = &dpvs_app;
-	memset(dpvs_app_ptr, 0, sizeof(dpvs_app));
-	IPVS_2_DPVS(dpvs_app_ptr, hint);
-	memcpy(&dpvs_svc, dpvs_app_ptr, sizeof(dpvs_app));
+	dpvs_svc_entry = &dpvs_svc.user;
+	IPVS_2_DPVS(dpvs_svc_entry, hint);
 	dpvs_svc.user.cid = cid;
 
 	if (dpvs_getsockopt(cpu2opt_svc(cid, DPVS_SO_GET_SERVICE), 


### PR DESCRIPTION
example：
ipvsadm -ln -H "snat-svc"
ipvsadm -E -H "snat-svc"