### PR TITLE
synproxy: fix fullnat tcp forwarding problem when defer_rs_syn enabled

### DIFF
--- a/conf/dpvs.conf.items
+++ b/conf/dpvs.conf.items
@@ -260,6 +260,7 @@ ipvs_defs {
             !    wscale                      <disable>
             !    timestamp                   <disable>
             }
+            close_client_window             <enable>
             !defer_rs_syn                   <disable>
             rs_syn_max_retry    3           <3, 1-99>
             ack_storm_thresh    10          <10, 1-999>

--- a/conf/dpvs.conf.sample
+++ b/conf/dpvs.conf.sample
@@ -324,6 +324,7 @@ ipvs_defs {
                 ! wscale
                 ! timestamp
             }
+            close_client_window
             ! defer_rs_syn
             rs_syn_max_retry    3
             ack_storm_thresh    10

--- a/conf/dpvs.conf.single-bond.sample
+++ b/conf/dpvs.conf.single-bond.sample
@@ -265,6 +265,7 @@ ipvs_defs {
                 ! wscale
                 ! timestamp
             }
+            close_client_window
             ! defer_rs_syn
             rs_syn_max_retry    3
             ack_storm_thresh    10

--- a/conf/dpvs.conf.single-nic.sample
+++ b/conf/dpvs.conf.single-nic.sample
@@ -240,6 +240,7 @@ ipvs_defs {
                 ! wscale
                 ! timestamp
             }
+            close_client_window
             ! defer_rs_syn
             rs_syn_max_retry    3
             ack_storm_thresh    10


### PR DESCRIPTION
Tcp reciece window of the client is closed in the first step of synproxy,
and client could only send window probe ack packets without payload in the
case. So it conflicts with the defer_rs_syn, which schedules ipvs connection
only when tcp ack packets with payload catched in the second step of synproxy.

Besides, a config item close_client_window is added to disable client window
close in the first step of synproxy.

Signed-off-by: ywc689 <ywc689@163.com>