### PR TITLE
Resolve compilation errors on Ubuntu 22.04

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -37,6 +37,11 @@ SRCDIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 # Addtional libs below are needed when using dynamic link.
 LIBS += -lpthread -lnuma -lrt -lm -ldl -lcrypto
 
+ifeq ($(shell pkg-config --exists libssl && echo 0),0)
+CFLAGS += $(shell pkg-config --cflags libssl)
+LIBS += $(shell pkg-config --static --libs libssl)
+endif
+
 include $(SRCDIR)/config.mk
 include $(SRCDIR)/dpdk.mk
 

--- a/src/ipvs/ip_vs_proto_icmp.c
+++ b/src/ipvs/ip_vs_proto_icmp.c
@@ -21,7 +21,7 @@
  * raychen@qiyi.com, July 2017.
  */
 #include <assert.h>
-#include <linux/icmp.h>
+#include <netinet/ip_icmp.h>
 #include <netinet/icmp6.h>
 #include "dpdk.h"
 #include "conf/common.h"
@@ -99,7 +99,7 @@ static int icmp_conn_sched(struct dp_vs_proto *proto,
         return EDPVS_INVPKT;
     }
 
-    svc = dp_vs_service_lookup(iph->af, iph->proto, &iph->daddr, 0, 0, 
+    svc = dp_vs_service_lookup(iph->af, iph->proto, &iph->daddr, 0, 0,
                                mbuf, NULL, &outwall, rte_lcore_id());
     if (!svc) {
         *verdict = INET_ACCEPT;

--- a/tools/keepalived/keepalived/core/layer4.c
+++ b/tools/keepalived/keepalived/core/layer4.c
@@ -27,7 +27,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <linux/icmp.h>
+#include <netinet/ip_icmp.h>
 #include <linux/icmpv6.h>
 #ifdef ERRQUEUE_NEEDS_SYS_TIME
 #include <sys/time.h>


### PR DESCRIPTION
1.Solve the problem of compiling errors with Ubuntu 22.04 and kernel version 5.15.68.1-microsoft-standard-WSL2.
2.The openssl versions of different operating systems are too different to compile successfully. The openssl header file and library file path can be specified during compilation, and the system openssl is no longer mandatory.