### PR TITLE
kni: fix possible alloc_q starvation

### DIFF
--- a/include/netif.h
+++ b/include/netif.h
@@ -256,6 +256,9 @@ struct netif_port {
     struct netif_ops        *netif_ops;
 } __rte_cache_aligned;
 
+/**************************** mbuf pool ********************************/
+extern struct rte_mempool *pktmbuf_pool[DPVS_MAX_SOCKET];
+
 /**************************** lcore API *******************************/
 int netif_xmit(struct rte_mbuf *mbuf, struct netif_port *dev);
 int netif_hard_xmit(struct rte_mbuf *mbuf, struct netif_port *dev);

--- a/src/netif.c
+++ b/src/netif.c
@@ -1033,7 +1033,7 @@ __rte_unused static void pkt_send_back(struct rte_mbuf *mbuf, struct netif_port 
 #endif
 
 /********************************************* mbufpool *******************************************/
-static struct rte_mempool *pktmbuf_pool[DPVS_MAX_SOCKET];
+struct rte_mempool *pktmbuf_pool[DPVS_MAX_SOCKET];
 
 static inline void netif_pktmbuf_pool_init(void)
 {
@@ -4238,7 +4238,6 @@ static void netif_port_init(void)
 
     this_eth_conf = default_port_conf;
 
-    rte_kni_init(NETIF_MAX_KNI);
     kni_init();
 
     for (pid = 0; pid < nports; pid++) {


### PR DESCRIPTION
The size of kni_mbuf_pool is 65535. DPDK KNI may be starvation when mbufs are exhausted. Many reasons cause the mbufs of the kni_mbuf_pool to be cached, such as kni_rx_ring_*, driver.

For example, under the configuration of 16 txqs + 4096 descriptors, since ixgbe uses lazy recycling, a maximum of 65536 mbufs will be cached.

Using a large enough mbuf pool is an easy fix. pktmbuf_pool is the best choice.

DPDK KNI starvation bug detail:
http://patches.dpdk.org/project/dpdk/patch/20221109060434.2012064-1-zhouyates@gmail.com/ http://patches.dpdk.org/project/dpdk/patch/20221230042338.1670768-1-zhouyates@gmail.com/