### PR TITLE
bugfix: new_vs quorum_up script will not be excuted

### DIFF
--- a/tools/keepalived/keepalived/check/ipwrapper.c
+++ b/tools/keepalived/keepalived/check/ipwrapper.c
@@ -1024,6 +1024,12 @@ clear_diff_rs(virtual_server_t *old_vs, virtual_server_t *new_vs, list old_check
 		}
 	}
 	clear_service_rs(old_vs, rs_to_remove, false);
+
+	//keep new_vs quorum_state_up same with old_vs
+	if (old_vs->quorum_state_up != new_vs->quorum_state_up) {
+		new_vs->quorum_state_up = old_vs->quorum_state_up;
+	}
+
 	free_list(&rs_to_remove);
 }
 


### PR DESCRIPTION
keepalived new_vs quorum_state_up always be true and quorum_up script will not be excuted when all old rs(healthcheck is alive) are removed and new rs(healthcheck is alive) add in same reload.