### PR TITLE
ci: fix unsupported Node20 problem

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,18 +17,22 @@ jobs:
     runs-on: self-hosted
     env:
       PKG_CONFIG_PATH: /data/dpdk/dpdklib/lib64/pkgconfig
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
-    - uses: actions/checkout@v2
-    - name: make
+    - name: Checkout Code
+      uses: actions/checkout@v3
+    - name: build
       run: make -j
       
   build-all:
     runs-on: self-hosted
     env:
       PKG_CONFIG_PATH: /data/dpdk/dpdklib/lib64/pkgconfig
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
-    - uses: actions/checkout@v2
-    - name: config
+    - name: Checkout Code
+      uses: actions/checkout@v3
+    - name: Config
       run: sed -i 's/=n$/=y/' config.mk
-    - name: make
+    - name: build
       run: make -j

--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -17,11 +17,13 @@ jobs:
     runs-on: self-hosted
     env:
       PKG_CONFIG_PATH: /data/dpdk/dpdklib/lib64/pkgconfig
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
-    - uses: actions/checkout@v2
-    - name: make
+    - name: Checkout Code
+      uses: actions/checkout@v3
+    - name: Build
       run: make -j
-    - name: install
+    - name: Install
       run: make install
-    - name: run-dpvs
+    - name: Run DPVS
       run: sudo dpvsci $(pwd)/bin/dpvs


### PR DESCRIPTION
This is a temporary fix, and hopefully can work until Spring 2025. https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/