### PR TITLE
netif: fix duplicate ARP replies or KNI packets being counted as dropped

### DIFF
--- a/src/netif.c
+++ b/src/netif.c
@@ -2497,7 +2497,7 @@ int netif_rcv_mbuf(struct netif_port *dev, lcoreid_t cid, struct rte_mbuf *mbuf,
 
     if (err == EDPVS_KNICONTINUE) {
         if (pkts_from_ring || forward2kni)
-            goto drop;
+            goto slient_free;
         if (unlikely(NULL == rte_pktmbuf_prepend(mbuf, (mbuf->data_off - data_off))))
             goto drop;
         kni_ingress(mbuf, dev);
@@ -2511,8 +2511,9 @@ done:
     return EDPVS_OK;
 
 drop:
-    rte_pktmbuf_free(mbuf);
     lcore_stats[cid].dropped++;
+slient_free:
+    rte_pktmbuf_free(mbuf);
     return EDPVS_DROP;
 }
 


### PR DESCRIPTION
补丁修复了下列情况的数据包被误统计为dropped的问题：

- 某个转发核收到arp reply后广播到其他转发核的数据包
- 标记NETIF_PORT_FLAG_FORWARD2KNI的port的数据包又被判断为EDPVS_KNICONTINUE

上述场景不再累计dropped计数
