### PR TITLE
Passive Update mode supported

### DIFF
--- a/tools/dpvs-agent/dpvs-agent-api.yaml
+++ b/tools/dpvs-agent/dpvs-agent-api.yaml
@@ -156,6 +156,12 @@ parameters:
       - off
     default: unset
     required: false
+  passive-update:
+    name: passiveUpdate
+    in: query
+    type: boolean
+    default: false
+    required: false
   version:
     name: version
     in: query
@@ -561,6 +567,9 @@ definitions:
         format: "uint32"
       Flags:
         type: "string"
+      RamFlags:
+        type: "integer"
+        format: "uint32"
       SynProxy:
         type: "string"
         enum:
@@ -1164,6 +1173,7 @@ paths:
       tags:
         - "virtualserver"
       parameters:
+        - "$ref": "#/parameters/passive-update"
         - "$ref": "#/parameters/snapshot"
         - "$ref": "#/parameters/service-id"
         - "$ref": "#/parameters/vs-config"
@@ -1381,6 +1391,7 @@ paths:
       tags:
         - "virtualserver"
       parameters:
+        - "$ref": "#/parameters/passive-update"
         - "$ref": "#/parameters/snapshot"
         - "$ref": "#/parameters/service-id"
         - "$ref": "#/parameters/rss-config"

--- a/tools/dpvs-agent/models/virtual_server_spec_expand.go
+++ b/tools/dpvs-agent/models/virtual_server_spec_expand.go
@@ -77,6 +77,9 @@ type VirtualServerSpecExpand struct {
 	// r ss
 	RSs *RealServerExpandList `json:"RSs,omitempty"`
 
+	// Ram flags
+	RAMFlags uint32 `json:"RamFlags,omitempty"`
+
 	// sched name
 	// Enum: [rr wrr wlc conhash]
 	SchedName string `json:"SchedName,omitempty"`

--- a/tools/dpvs-agent/pkg/ipc/types/getmodel.go
+++ b/tools/dpvs-agent/pkg/ipc/types/getmodel.go
@@ -37,6 +37,7 @@ func (vs *VirtualServerSpec) GetModel() *models.VirtualServerSpecExpand {
 		Match:           vs.match.GetModel(),
 		Stats:           vs.stats.GetModel(),
 		DestCheck:       vs.GetDestCheck(),
+		RAMFlags:        vs.GetFlags(),
 	}
 
 	flags := ""

--- a/tools/dpvs-agent/pkg/ipc/types/realserver.go
+++ b/tools/dpvs-agent/pkg/ipc/types/realserver.go
@@ -31,6 +31,20 @@ import (
 	"github.com/dpvs-agent/pkg/ipc/pool"
 )
 
+type SliceRealServerSpec []*RealServerSpec
+
+func (rss SliceRealServerSpec) Len() int {
+	return len(rss)
+}
+
+func (rss SliceRealServerSpec) Swap(i, j int) {
+	rss[i], rss[j] = rss[j], rss[i]
+}
+
+func (rss SliceRealServerSpec) Less(i, j int) bool {
+	return rss[i].ID() < rss[j].ID()
+}
+
 type RealServerSpec struct {
 	af           uint32
 	port         uint16

--- a/tools/dpvs-agent/pkg/ipc/types/snapshot.go
+++ b/tools/dpvs-agent/pkg/ipc/types/snapshot.go
@@ -207,6 +207,22 @@ func (spec *VirtualServerSpecExpandModel) ID() string {
 	return fmt.Sprintf("%s-%d-%s", net.ParseIP(spec.Addr).String(), spec.Port, proto)
 }
 
+type SliceRealServerSpecExpandModel []*models.RealServerSpecExpand
+
+func (rss SliceRealServerSpecExpandModel) Len() int {
+	return len(rss)
+}
+
+func (rss SliceRealServerSpecExpandModel) Swap(i, j int) {
+	rss[i], rss[j] = rss[j], rss[i]
+}
+
+func (rss SliceRealServerSpecExpandModel) Less(i, j int) bool {
+	rs1 := (*RealServerSpecExpandModel)(rss[i])
+	rs2 := (*RealServerSpecExpandModel)(rss[j])
+	return rs1.ID() < rs2.ID()
+}
+
 func (node *NodeSnapshot) LoadFrom(cacheFile string, logger hclog.Logger) error {
 	content, err := os.ReadFile(cacheFile)
 	if err != nil {

--- a/tools/dpvs-agent/restapi/embedded_spec.go
+++ b/tools/dpvs-agent/restapi/embedded_spec.go
@@ -971,6 +971,9 @@ func init() {
         "summary": "create or update virtual server",
         "parameters": [
           {
+            "$ref": "#/parameters/passive-update"
+          },
+          {
             "$ref": "#/parameters/snapshot"
           },
           {
@@ -1600,6 +1603,9 @@ func init() {
         ],
         "summary": "Update fully real server list to vip:port:proto",
         "parameters": [
+          {
+            "$ref": "#/parameters/passive-update"
+          },
           {
             "$ref": "#/parameters/snapshot"
           },
@@ -2482,6 +2488,10 @@ func init() {
         "RSs": {
           "$ref": "#/definitions/RealServerExpandList"
         },
+        "RamFlags": {
+          "type": "integer",
+          "format": "uint32"
+        },
         "SchedName": {
           "type": "string",
           "enum": [
@@ -2668,6 +2678,12 @@ func init() {
       "type": "string",
       "default": "unset",
       "name": "link",
+      "in": "query"
+    },
+    "passive-update": {
+      "type": "boolean",
+      "default": false,
+      "name": "passiveUpdate",
       "in": "query"
     },
     "promisc": {
@@ -3957,6 +3973,12 @@ func init() {
         "parameters": [
           {
             "type": "boolean",
+            "default": false,
+            "name": "passiveUpdate",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
             "default": true,
             "name": "snapshot",
             "in": "query"
@@ -4688,6 +4710,12 @@ func init() {
         ],
         "summary": "Update fully real server list to vip:port:proto",
         "parameters": [
+          {
+            "type": "boolean",
+            "default": false,
+            "name": "passiveUpdate",
+            "in": "query"
+          },
           {
             "type": "boolean",
             "default": true,
@@ -5597,6 +5625,10 @@ func init() {
         "RSs": {
           "$ref": "#/definitions/RealServerExpandList"
         },
+        "RamFlags": {
+          "type": "integer",
+          "format": "uint32"
+        },
         "SchedName": {
           "type": "string",
           "enum": [
@@ -5783,6 +5815,12 @@ func init() {
       "type": "string",
       "default": "unset",
       "name": "link",
+      "in": "query"
+    },
+    "passive-update": {
+      "type": "boolean",
+      "default": false,
+      "name": "passiveUpdate",
       "in": "query"
     },
     "promisc": {

--- a/tools/dpvs-agent/restapi/operations/virtualserver/post_vs_vip_port_rs_parameters.go
+++ b/tools/dpvs-agent/restapi/operations/virtualserver/post_vs_vip_port_rs_parameters.go
@@ -25,10 +25,14 @@ func NewPostVsVipPortRsParams() PostVsVipPortRsParams {
 	var (
 		// initialize parameters with default values
 
+		passiveUpdateDefault = bool(false)
+
 		snapshotDefault = bool(true)
 	)
 
 	return PostVsVipPortRsParams{
+		PassiveUpdate: &passiveUpdateDefault,
+
 		Snapshot: &snapshotDefault,
 	}
 }
@@ -47,6 +51,11 @@ type PostVsVipPortRsParams struct {
 	  In: path
 	*/
 	VipPort string
+	/*
+	  In: query
+	  Default: false
+	*/
+	PassiveUpdate *bool
 	/*
 	  In: body
 	*/
@@ -71,6 +80,11 @@ func (o *PostVsVipPortRsParams) BindRequest(r *http.Request, route *middleware.M
 
 	rVipPort, rhkVipPort, _ := route.Params.GetOK("VipPort")
 	if err := o.bindVipPort(rVipPort, rhkVipPort, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qPassiveUpdate, qhkPassiveUpdate, _ := qs.GetOK("passiveUpdate")
+	if err := o.bindPassiveUpdate(qPassiveUpdate, qhkPassiveUpdate, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -116,6 +130,30 @@ func (o *PostVsVipPortRsParams) bindVipPort(rawData []string, hasKey bool, forma
 	// Required: true
 	// Parameter is provided by construction from the route
 	o.VipPort = raw
+
+	return nil
+}
+
+// bindPassiveUpdate binds and validates parameter PassiveUpdate from query.
+func (o *PostVsVipPortRsParams) bindPassiveUpdate(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		// Default values have been previously initialized by NewPostVsVipPortRsParams()
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("passiveUpdate", "query", "bool", raw)
+	}
+	o.PassiveUpdate = &value
 
 	return nil
 }

--- a/tools/dpvs-agent/restapi/operations/virtualserver/post_vs_vip_port_rs_urlbuilder.go
+++ b/tools/dpvs-agent/restapi/operations/virtualserver/post_vs_vip_port_rs_urlbuilder.go
@@ -18,7 +18,8 @@ import (
 type PostVsVipPortRsURL struct {
 	VipPort string
 
-	Snapshot *bool
+	PassiveUpdate *bool
+	Snapshot      *bool
 
 	_basePath string
 	// avoid unkeyed usage
@@ -60,6 +61,14 @@ func (o *PostVsVipPortRsURL) Build() (*url.URL, error) {
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 
 	qs := make(url.Values)
+
+	var passiveUpdateQ string
+	if o.PassiveUpdate != nil {
+		passiveUpdateQ = swag.FormatBool(*o.PassiveUpdate)
+	}
+	if passiveUpdateQ != "" {
+		qs.Set("passiveUpdate", passiveUpdateQ)
+	}
 
 	var snapshotQ string
 	if o.Snapshot != nil {

--- a/tools/dpvs-agent/restapi/operations/virtualserver/put_vs_vip_port_parameters.go
+++ b/tools/dpvs-agent/restapi/operations/virtualserver/put_vs_vip_port_parameters.go
@@ -25,10 +25,13 @@ func NewPutVsVipPortParams() PutVsVipPortParams {
 	var (
 		// initialize parameters with default values
 
-		snapshotDefault = bool(true)
+		passiveUpdateDefault = bool(false)
+		snapshotDefault      = bool(true)
 	)
 
 	return PutVsVipPortParams{
+		PassiveUpdate: &passiveUpdateDefault,
+
 		Snapshot: &snapshotDefault,
 	}
 }
@@ -47,6 +50,11 @@ type PutVsVipPortParams struct {
 	  In: path
 	*/
 	VipPort string
+	/*
+	  In: query
+	  Default: false
+	*/
+	PassiveUpdate *bool
 	/*
 	  In: query
 	  Default: true
@@ -71,6 +79,11 @@ func (o *PutVsVipPortParams) BindRequest(r *http.Request, route *middleware.Matc
 
 	rVipPort, rhkVipPort, _ := route.Params.GetOK("VipPort")
 	if err := o.bindVipPort(rVipPort, rhkVipPort, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qPassiveUpdate, qhkPassiveUpdate, _ := qs.GetOK("passiveUpdate")
+	if err := o.bindPassiveUpdate(qPassiveUpdate, qhkPassiveUpdate, route.Formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -116,6 +129,30 @@ func (o *PutVsVipPortParams) bindVipPort(rawData []string, hasKey bool, formats 
 	// Required: true
 	// Parameter is provided by construction from the route
 	o.VipPort = raw
+
+	return nil
+}
+
+// bindPassiveUpdate binds and validates parameter PassiveUpdate from query.
+func (o *PutVsVipPortParams) bindPassiveUpdate(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		// Default values have been previously initialized by NewPutVsVipPortParams()
+		return nil
+	}
+
+	value, err := swag.ConvertBool(raw)
+	if err != nil {
+		return errors.InvalidType("passiveUpdate", "query", "bool", raw)
+	}
+	o.PassiveUpdate = &value
 
 	return nil
 }

--- a/tools/dpvs-agent/restapi/operations/virtualserver/put_vs_vip_port_urlbuilder.go
+++ b/tools/dpvs-agent/restapi/operations/virtualserver/put_vs_vip_port_urlbuilder.go
@@ -18,7 +18,8 @@ import (
 type PutVsVipPortURL struct {
 	VipPort string
 
-	Snapshot *bool
+	PassiveUpdate *bool
+	Snapshot      *bool
 
 	_basePath string
 	// avoid unkeyed usage
@@ -60,6 +61,14 @@ func (o *PutVsVipPortURL) Build() (*url.URL, error) {
 	_result.Path = golangswaggerpaths.Join(_basePath, _path)
 
 	qs := make(url.Values)
+
+	var passiveUpdateQ string
+	if o.PassiveUpdate != nil {
+		passiveUpdateQ = swag.FormatBool(*o.PassiveUpdate)
+	}
+	if passiveUpdateQ != "" {
+		qs.Set("passiveUpdate", passiveUpdateQ)
+	}
 
 	var snapshotQ string
 	if o.Snapshot != nil {


### PR DESCRIPTION
There will rescheduled to the header realserver while  DPVS_SO_SET_ADD | DPVS_SO_SET_EDIT occurred.
The high frequent service changes may lead to backend load imbalance due to schedule resets.

POST /vs/{VipPort}/rs?passiveUpdate=true
PUT  /vs/{VipPort}?passiveUpdate=true



