### PR TITLE
treewide: 迁移 OpenSSL 3.0 已弃用的 MD5/SHA 摘要接口

### DIFF
--- a/src/inetaddr.c
+++ b/src/inetaddr.c
@@ -17,6 +17,7 @@
  */
 #include <assert.h>
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 #include "dpdk.h"
 #include "ctrl.h"
 #include "netif.h"
@@ -306,7 +307,9 @@ static int inet6_addr_gen_stable(struct in6_addr secret, struct inet_device *ide
 #define MAX_RETRY   8
     struct in6_addr temp;
     union {
-        unsigned char data[SHA256_DIGEST_LENGTH];
+        /* must hold a full SHA-512 digest (64 bytes); only the first two
+         * words are consumed below */
+        unsigned char data[SHA512_DIGEST_LENGTH];
         uint32_t data_word[2];
     } md;
     struct {
@@ -325,7 +328,9 @@ static int inet6_addr_gen_stable(struct in6_addr secret, struct inet_device *ide
     while (1) {
         data.dad_count = dad_count++;
         memset(&md, 0, sizeof(md));
-        SHA512((const unsigned char*)&data, sizeof(data), md.data);
+        /* OpenSSL 3.0 deprecates the one-shot SHA512(); use the EVP one-shot */
+        if (EVP_Digest(&data, sizeof(data), md.data, NULL, EVP_sha512(), NULL) != 1)
+            return EDPVS_INVAL;
         temp = *addr;
         temp.s6_addr32[2] = md.data_word[0];
         temp.s6_addr32[3] = md.data_word[1];

--- a/src/ipvs/ip_vs_proto_tcp.c
+++ b/src/ipvs/ip_vs_proto_tcp.c
@@ -37,6 +37,7 @@
  * like tcphdr.syn, so use standard definition. */
 #include <netinet/tcp.h>
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 #include "ipvs/redirect.h"
 #include "ipvs/proxy_proto.h"
 
@@ -234,9 +235,17 @@ static inline uint32_t tcp_secure_sequence_number(uint32_t saddr, uint32_t daddr
     data[2] = ((uint16_t)sport << 16) + (uint16_t)dport;
     data[3] = tcp_secret;
 
-    SHA1((unsigned char *)data, sizeof(data), hash);
-    hash0 = hash[0];
-    return seq_scale(*(uint32_t *)&hash0);
+    /* OpenSSL 3.0 deprecates the one-shot SHA1(); use the EVP one-shot.
+     * Only self-consistency matters here (internal ISN), so any digest value
+     * is fine as long as it is deterministic. EVP_Digest of a fixed buffer with
+     * a built-in digest should never fail; if it somehow does, fall back to a
+     * deterministic value rather than 0, which tcp_in_init_seq() treats as the
+     * "uninitialized" sentinel. */
+    if (EVP_Digest(data, sizeof(data), hash, NULL, EVP_sha1(), NULL) == 1)
+        memcpy(&hash0, hash, sizeof(hash0));
+    else
+        hash0 = data[0] ^ data[1] ^ data[2] ^ data[3];
+    return seq_scale(hash0);
 }
 
 static inline void tcp_in_init_seq(struct dp_vs_conn *conn,

--- a/src/ipvs/ip_vs_synproxy.c
+++ b/src/ipvs/ip_vs_synproxy.c
@@ -21,6 +21,7 @@
 #include <fcntl.h>
 #include <netinet/ip.h>
 #include <netinet/tcp.h>
+#include <openssl/evp.h>
 #include <openssl/md5.h>
 #include "conf/common.h"
 #include "dpdk.h"
@@ -206,6 +207,7 @@ cookie_hash(uint32_t saddr, uint32_t daddr,
     unsigned char hash[MD5_DIGEST_LENGTH];
     uint32_t data[5];
     uint32_t hvalue;
+    EVP_MD_CTX *mdctx;
 
     data[0] = saddr;
     data[1] = daddr;
@@ -213,7 +215,17 @@ cookie_hash(uint32_t saddr, uint32_t daddr,
     data[3] = count;
     data[4] = g_net_secret[c][0];
 
-    MD5((unsigned char *)data, sizeof(data), hash);
+    mdctx = EVP_MD_CTX_new();
+    if (mdctx == NULL) {
+        return 0;
+    }
+    if (EVP_DigestInit_ex(mdctx, EVP_md5(), NULL) != 1 ||
+        EVP_DigestUpdate(mdctx, data, sizeof(data)) != 1 ||
+        EVP_DigestFinal_ex(mdctx, hash, NULL) != 1) {
+        EVP_MD_CTX_free(mdctx);
+        return 0;
+    }
+    EVP_MD_CTX_free(mdctx);
     memcpy(&hvalue, hash, sizeof(hvalue));
 
     return hvalue;
@@ -278,6 +290,7 @@ cookie_hash_v6(const struct in6_addr *saddr,
     int i;
     uint32_t hvalue, data[MD5_LBLOCK];
     unsigned char hash[MD5_DIGEST_LENGTH];
+    EVP_MD_CTX *mdctx;
 
     for (i = 0; i < 4; i++)
         data[i] = g_net_secret[c][i] + ((uint32_t *)saddr)[i];
@@ -290,7 +303,17 @@ cookie_hash_v6(const struct in6_addr *saddr,
     for (i = 10; i < MD5_LBLOCK; i++)
         data[i] = g_net_secret[c][i];
 
-    MD5((unsigned char*)data, sizeof(data), hash);
+    mdctx = EVP_MD_CTX_new();
+    if (mdctx == NULL) {
+        return 0;
+    }
+    if (EVP_DigestInit_ex(mdctx, EVP_md5(), NULL) != 1 ||
+        EVP_DigestUpdate(mdctx, data, sizeof(data)) != 1 ||
+        EVP_DigestFinal_ex(mdctx, hash, NULL) != 1) {
+        EVP_MD_CTX_free(mdctx);
+        return 0;
+    }
+    EVP_MD_CTX_free(mdctx);
     memcpy(&hvalue, hash, sizeof(hvalue));
 
     return hvalue;

--- a/src/ipvs/ip_vs_synproxy.c
+++ b/src/ipvs/ip_vs_synproxy.c
@@ -21,8 +21,8 @@
 #include <fcntl.h>
 #include <netinet/ip.h>
 #include <netinet/tcp.h>
-#include <openssl/md5.h>
 #include "conf/common.h"
+#include "md5.h"
 #include "dpdk.h"
 #include "ipvs/ipvs.h"
 #include "ipvs/synproxy.h"
@@ -82,10 +82,22 @@ static struct dpvs_timer g_second_timer;
 #endif
 
 /*
- * syncookies using digest function from openssl libray,
- * a little difference from kernel, which uses md5_transform
- * */
-static uint32_t g_net_secret[2][MD5_LBLOCK];
+ * syncookies using the in-tree md5_transform() (include/md5.h), the same
+ * primitive the Linux kernel uses for SYN cookies. This avoids the OpenSSL
+ * MD5() one-shot API deprecated since OpenSSL 3.0, and keeps the hash off the
+ * heap on the per-SYN hot path (no EVP context alloc/free per packet).
+ *
+ * Note: the resulting cookie value differs from the previous full-MD5 output,
+ * so cookies are not interchangeable across this change. During a rolling
+ * upgrade, in-flight cookies minted by the old binary fail validation on the
+ * new one (and vice versa); clients simply retransmit the SYN, so the impact
+ * is a brief transient during the swap.
+ */
+
+/* MD5 consumes the message one 64-byte block (MD5_BLOCK_WORDS words) at a time */
+#define MD5_BLOCK_WORDS (MD5_MESSAGE_BYTES / (int)sizeof(uint32_t))
+
+static uint32_t g_net_secret[2][MD5_BLOCK_WORDS];
 static struct dpvs_timer g_minute_timer;
 static rte_atomic32_t g_minute_count;
 
@@ -145,7 +157,7 @@ int dp_vs_synproxy_init(void)
     struct timeval tv;
 
     if (generate_random_key(g_net_secret, sizeof(g_net_secret))) {
-        for (i = 0; i < MD5_LBLOCK; i++) {
+        for (i = 0; i < MD5_BLOCK_WORDS; i++) {
             g_net_secret[0][i] = (uint32_t)random();
             g_net_secret[1][i] = (uint32_t)random();
         }
@@ -198,14 +210,34 @@ int dp_vs_synproxy_term(void)
 #define COOKIEBITS 24 /* Upper bits store count */
 #define COOKIEMASK (((uint32_t)1 << COOKIEBITS) - 1)
 
+/*
+ * Hash one 64-byte (MD5_BLOCK_WORDS words) message block with a single
+ * md5_transform() round and fold the resulting state into a 32-bit value.
+ * The per-key secret (g_net_secret) is mixed into the block by the callers, so
+ * the result stays keyed and hard to forge without the secret; a raw
+ * single-block transform (no length padding) is enough for SYN cookies, which
+ * only require this keyed self-consistency between generation and validation.
+ * Unlike the OpenSSL EVP path it allocates nothing and cannot fail, so callers
+ * no longer need an error sentinel.
+ */
+static inline uint32_t cookie_md5_hash(const uint32_t block[MD5_BLOCK_WORDS])
+{
+    /* MD5 initial state (RFC 1321) */
+    uint32_t hash[MD5_DIGEST_WORDS] = {
+        0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476,
+    };
+
+    md5_transform(hash, block);
+
+    return hash[0];
+}
+
 static uint32_t
 cookie_hash(uint32_t saddr, uint32_t daddr,
             uint16_t sport, uint16_t dport,
             uint32_t count, int c)
 {
-    unsigned char hash[MD5_DIGEST_LENGTH];
-    uint32_t data[5];
-    uint32_t hvalue;
+    uint32_t data[MD5_BLOCK_WORDS] = { 0 };
 
     data[0] = saddr;
     data[1] = daddr;
@@ -213,10 +245,7 @@ cookie_hash(uint32_t saddr, uint32_t daddr,
     data[3] = count;
     data[4] = g_net_secret[c][0];
 
-    MD5((unsigned char *)data, sizeof(data), hash);
-    memcpy(&hvalue, hash, sizeof(hvalue));
-
-    return hvalue;
+    return cookie_md5_hash(data);
 }
 
 static uint32_t
@@ -276,8 +305,7 @@ cookie_hash_v6(const struct in6_addr *saddr,
                uint32_t count, int c)
 {
     int i;
-    uint32_t hvalue, data[MD5_LBLOCK];
-    unsigned char hash[MD5_DIGEST_LENGTH];
+    uint32_t data[MD5_BLOCK_WORDS];
 
     for (i = 0; i < 4; i++)
         data[i] = g_net_secret[c][i] + ((uint32_t *)saddr)[i];
@@ -287,13 +315,10 @@ cookie_hash_v6(const struct in6_addr *saddr,
     data[8] = g_net_secret[c][8] + ((sport << 16) + dport);
     data[9] = g_net_secret[c][9] + count;
 
-    for (i = 10; i < MD5_LBLOCK; i++)
+    for (i = 10; i < MD5_BLOCK_WORDS; i++)
         data[i] = g_net_secret[c][i];
 
-    MD5((unsigned char*)data, sizeof(data), hash);
-    memcpy(&hvalue, hash, sizeof(hvalue));
-
-    return hvalue;
+    return cookie_md5_hash(data);
 }
 
 static uint32_t

--- a/tools/keepalived/configure.ac
+++ b/tools/keepalived/configure.ac
@@ -957,7 +957,7 @@ AC_CHECK_HEADERS([openssl/ssl.h openssl/err.h], [],
     NEED_SSL=no
     break
   ])
-AC_CHECK_HEADERS([openssl/md5.h], [],
+AC_CHECK_HEADERS([openssl/md5.h openssl/evp.h], [],
   [
     if test $NEED_MD5 = yes; then
       AC_MSG_ERROR([
@@ -978,7 +978,10 @@ else
 fi
 
 EXTRA_LIBS=`echo $OPENSSL_LIBS | sed -e "s/-lcrypto//"`
-AC_CHECK_LIB(crypto, MD5_Init, [],
+dnl MD5 is now used via the EVP API (OpenSSL 3.0 deprecates the MD5_* one-shot
+dnl API); probe a non-deprecated EVP symbol so the check also passes against an
+dnl OpenSSL built with no-deprecated.
+AC_CHECK_LIB(crypto, EVP_DigestInit_ex, [],
   [
     if test $NEED_MD5 = yes; then
       AC_MSG_ERROR([OpenSSL MD5 libraries are required])
@@ -2233,13 +2236,15 @@ dnl ----[ SHA1 or not ? ]----
 SHA1_SUPPORT=No
 if test "${enable_sha1}" = yes; then
   AC_CHECK_HEADERS(openssl/sha.h,,AC_MSG_ERROR([unable to find openssl/sha.h]))
-  AC_CHECK_LIB(crypto, SHA1_Init,,
+  dnl SHA1 is now used via the EVP API; probe the non-deprecated EVP_sha1 symbol
+  dnl so SHA1 support is detected even on an OpenSSL built with no-deprecated.
+  AC_CHECK_LIB(crypto, EVP_sha1,,
     [
       dnl libcrypto can require -fpic
-      AS_UNSET([ac_cv_lib_crypto_SHA1_Init])
+      AS_UNSET([ac_cv_lib_crypto_EVP_sha1])
       SAV_CFLAGS=$CFLAGS
       CFLAGS="$CFLAGS -fpic"
-      AC_CHECK_LIB(crypto, SHA1_Init,,AC_MSG_ERROR([SHA1 in OpenSSL required]))
+      AC_CHECK_LIB(crypto, EVP_sha1,,AC_MSG_ERROR([SHA1 in OpenSSL required]))
       CFLAGS=$SAV_CFLAGS
       add_to_var([KA_CFLAGS],[-fpic])
     ])

--- a/tools/keepalived/genhash/http.c
+++ b/tools/keepalived/genhash/http.c
@@ -24,6 +24,7 @@
 
 /* system includes */
 #include <openssl/err.h>
+#include <openssl/evp.h>
 
 /* keepalived includes */
 #include "utils.h"
@@ -76,20 +77,66 @@ static const char *request_template_ipv6 =
  *   finalize    /     epilog
  */
 
+/*
+ * EVP adapters behind the hash_init_f/update_f/final_f typedefs.
+ * OpenSSL 3.0 deprecates the legacy MD5/SHA1 one-shot APIs, and their
+ * signatures no longer match the typedefs cleanly, so wrap the EVP API instead.
+ */
+static int
+genhash_md5_init(hash_context_t *ctx)
+{
+	ctx->ctx = EVP_MD_CTX_new();
+	if (ctx->ctx == NULL)
+		return 0;
+	return EVP_DigestInit_ex(ctx->ctx, EVP_md5(), NULL);
+}
+
+#ifdef _WITH_SHA1_
+static int
+genhash_sha1_init(hash_context_t *ctx)
+{
+	ctx->ctx = EVP_MD_CTX_new();
+	if (ctx->ctx == NULL)
+		return 0;
+	return EVP_DigestInit_ex(ctx->ctx, EVP_sha1(), NULL);
+}
+#endif
+
+static int
+genhash_digest_update(hash_context_t *ctx, const void *data, unsigned long len)
+{
+	if (ctx->ctx == NULL)
+		return 0;
+	return EVP_DigestUpdate(ctx->ctx, data, len);
+}
+
+static int
+genhash_digest_final(unsigned char *md, hash_context_t *ctx)
+{
+	int r = 0;
+
+	if (ctx->ctx) {
+		r = EVP_DigestFinal_ex(ctx->ctx, md, NULL);
+		EVP_MD_CTX_free(ctx->ctx);
+		ctx->ctx = NULL;
+	}
+	return r;
+}
+
 const hash_t hashes[hash_guard] = {
 	[hash_md5] = {
-		(hash_init_f) MD5_Init,
-		(hash_update_f) MD5_Update,
-		(hash_final_f) MD5_Final,
+		genhash_md5_init,
+		genhash_digest_update,
+		genhash_digest_final,
 		MD5_DIGEST_LENGTH,
 		"MD5",
 		"MD5SUM",
 	},
 #ifdef _WITH_SHA1_
 	[hash_sha1] = {
-		(hash_init_f) SHA1_Init,
-		(hash_update_f) SHA1_Update,
-		(hash_final_f) SHA1_Final,
+		genhash_sha1_init,
+		genhash_digest_update,
+		genhash_digest_final,
 		SHA_DIGEST_LENGTH,
 		"SHA1",
 		"SHA1SUM",
@@ -105,6 +152,14 @@ const hash_t hashes[hash_guard] = {
 		((sock)->hash->update(&(sock)->context, (buf), (sock)->content_len == -1 || (sock)->content_len - (sock)->rx_bytes >= len ? len : (sock)->content_len - (sock)->rx_bytes))
 #define HASH_FINAL(sock, digest) \
 	((sock)->hash->final((digest), &(sock)->context))
+/* release the EVP context if HASH_FINAL never ran (e.g. timeout/error path) */
+#define HASH_CLEANUP(sock) \
+	do { \
+		if ((sock)->context.ctx) { \
+			EVP_MD_CTX_free((sock)->context.ctx); \
+			(sock)->context.ctx = NULL; \
+		} \
+	} while (0)
 
 /* free allocated pieces */
 static void
@@ -117,6 +172,9 @@ free_all(thread_ref_t thread)
 
 	if (sock_obj->buffer)
 		FREE(sock_obj->buffer);
+
+	/* free the digest context if it was allocated but never finalized */
+	HASH_CLEANUP(sock_obj);
 
 	/*
 	 * Decrement the current global get number.
@@ -145,20 +203,26 @@ finalize(thread_ref_t thread)
 	int i;
 
 	/* Compute final hash digest */
-	HASH_FINAL(sock_obj, digest);
-	if (req->verbose) {
-		printf("\n");
-		printf(HTML_HASH);
-		dump_buffer((char *) digest, digest_length, stdout, 0);
+	if (!HASH_FINAL(sock_obj, digest)) {
+		/* digest could not be computed: report failure instead of
+		 * printing an all-zero digest as if it were valid */
+		fprintf(stderr, "Hash computation failed for [%s]\n", req->url);
+		exit_code = 1;
+	} else {
+		if (req->verbose) {
+			printf("\n");
+			printf(HTML_HASH);
+			dump_buffer((char *) digest, digest_length, stdout, 0);
 
-		printf(HTML_HASH_FINAL);
+			printf(HTML_HASH_FINAL);
+		}
+		printf("%s = ", HASH_LABEL(sock_obj));
+		for (i = 0; i < digest_length; i++)
+			printf("%02x", digest[i]);
+		if (sock_obj->content_len != -1 && sock_obj->content_len != sock_obj->rx_bytes)
+			printf ("\nWARNING - Content-Length (%zd) does not match received bytes (%zd).", sock_obj->content_len, sock_obj->rx_bytes);
+		printf("\n\n");
 	}
-	printf("%s = ", HASH_LABEL(sock_obj));
-	for (i = 0; i < digest_length; i++)
-		printf("%02x", digest[i]);
-	if (sock_obj->content_len != -1 && sock_obj->content_len != sock_obj->rx_bytes)
-		printf ("\nWARNING - Content-Length (%zd) does not match received bytes (%zd).", sock_obj->content_len, sock_obj->rx_bytes);
-	printf("\n\n");
 
 	DBG("Finalize : [%s]\n", req->url);
 	free_all(thread);
@@ -373,7 +437,10 @@ http_request_thread(thread_ref_t thread)
 
 	/* Initalize the hash context */
 	sock_obj->hash = &hashes[req->hash];
-	HASH_INIT(sock_obj);
+	if (!HASH_INIT(sock_obj)) {
+		fprintf(stderr, "Unable to initialize hash context\n");
+		exit_code = 1;
+	}
 
 	sock_obj->rx_bytes = 0;
 

--- a/tools/keepalived/genhash/include/hash.h
+++ b/tools/keepalived/genhash/include/hash.h
@@ -25,9 +25,10 @@
 #define _HASH_H
 
 /* system includes */
-#include <openssl/md5.h>
+#include <openssl/evp.h>
+#include <openssl/md5.h>	/* for MD5_DIGEST_LENGTH (not deprecated) */
 #ifdef _WITH_SHA1_
-#include <openssl/sha.h>
+#include <openssl/sha.h>	/* for SHA_DIGEST_LENGTH (not deprecated) */
 #endif
 
 /* available hashes enumeration */
@@ -41,15 +42,11 @@ enum feat_hashes {
 	hash_default = hash_md5,
 };
 
-typedef union {
-	MD5_CTX			md5;
-#ifdef _WITH_SHA1_
-	SHA_CTX			sha;
-#endif
-	/* this is due to poor C standard/draft wording (wrapped):
-	   https://groups.google.com/forum/#!msg/comp.lang.c/
-	   1kQMGXhgn4I/0VBEYG_ji44J */
-	char			*dummy;
+typedef struct {
+	/* OpenSSL 3.0 deprecates the legacy MD5/SHA1 one-shot APIs; use a single
+	   EVP context. Allocated by the init wrapper, freed by the final wrapper
+	   (or by HASH_CLEANUP on the error path). */
+	EVP_MD_CTX		*ctx;
 } hash_context_t;
 
 typedef int (*hash_init_f)(hash_context_t *);

--- a/tools/keepalived/keepalived/check/check_http.c
+++ b/tools/keepalived/keepalived/check/check_http.c
@@ -24,6 +24,7 @@
 #include "config.h"
 
 #include <openssl/err.h>
+#include <openssl/evp.h>
 #include <unistd.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -289,6 +290,10 @@ free_http_request(request_t *req)
 {
 	if(!req)
 		return;
+	if (req->context) {
+		EVP_MD_CTX_free(req->context);
+		req->context = NULL;
+	}
 	if (req->ssl)
 		SSL_free(req->ssl);
 	if (req->buffer)
@@ -1345,9 +1350,12 @@ http_process_response(request_t *req, size_t r, url_t *url)
 			req->content_len = extract_content_length(req->buffer, req->len);
 			r = req->len - (size_t)(req->extracted - req->buffer);
 			if (r && url->digest) {
-				if (req->content_len == SIZE_MAX || req->content_len > req->rx_bytes)
-					MD5_Update(&req->context, req->extracted,
-						   req->content_len == SIZE_MAX || req->content_len >= req->rx_bytes + r ? r : req->content_len - req->rx_bytes);
+				if (req->context &&
+				    (req->content_len == SIZE_MAX || req->content_len > req->rx_bytes)) {
+					if (EVP_DigestUpdate(req->context, req->extracted,
+						   req->content_len == SIZE_MAX || req->content_len >= req->rx_bytes + r ? r : req->content_len - req->rx_bytes) != 1)
+						log_message(LOG_INFO, "HTTP digest update failed");
+				}
 			}
 
 			req->rx_bytes = r;
@@ -1357,10 +1365,11 @@ http_process_response(request_t *req, size_t r, url_t *url)
 				req->len = 0;
 		}
 	} else if (req->len) {
-		if (url->digest &&
+		if (url->digest && req->context &&
 		    (req->content_len == SIZE_MAX || req->content_len > req->rx_bytes)) {
-			MD5_Update(&req->context, req->buffer + old_req_len,
-				   req->content_len == SIZE_MAX || req->content_len >= req->rx_bytes + r ? r : req->content_len - req->rx_bytes);
+			if (EVP_DigestUpdate(req->context, req->buffer + old_req_len,
+				   req->content_len == SIZE_MAX || req->content_len >= req->rx_bytes + r ? r : req->content_len - req->rx_bytes) != 1)
+				log_message(LOG_INFO, "HTTP digest update failed");
 		}
 
 		req->rx_bytes += req->len;
@@ -1403,8 +1412,19 @@ http_read_thread(thread_ref_t thread)
 
 	if (r <= 0) {	/* -1:error , 0:EOF */
 		/* All the HTTP stream has been parsed */
-		if (url->digest)
-			MD5_Final(digest, &req->context);
+		if (url->digest) {
+			if (req->context) {
+				if (EVP_DigestFinal_ex(req->context, digest, NULL) != 1) {
+					log_message(LOG_INFO, "HTTP digest finalization failed");
+					/* digest is now indeterminate: force a mismatch */
+					memset(digest, 0, MD5_DIGEST_LENGTH);
+				}
+				EVP_MD_CTX_free(req->context);
+				req->context = NULL;
+			} else
+				/* digest could not be computed: force a mismatch */
+				memset(digest, 0, MD5_DIGEST_LENGTH);
+		}
 
 		if (r == -1) {
 			/* We have encountered a real read error */
@@ -1457,8 +1477,17 @@ http_response_thread(thread_ref_t thread)
 	req->num_match_calls = 0;
 #endif
 #endif
-	if (url->digest)
-		MD5_Init(&req->context);
+	if (url->digest) {
+		req->context = EVP_MD_CTX_new();
+		if (req->context == NULL ||
+		    EVP_DigestInit_ex(req->context, EVP_md5(), NULL) != 1) {
+			log_message(LOG_INFO, "Unable to initialize MD5 digest context");
+			if (req->context) {
+				EVP_MD_CTX_free(req->context);
+				req->context = NULL;
+			}
+		}
+	}
 
 	/* Register asynchronous http/ssl read thread */
 	if (http_get_check->proto == PROTO_SSL)

--- a/tools/keepalived/keepalived/check/check_ssl.c
+++ b/tools/keepalived/keepalived/check/check_ssl.c
@@ -27,6 +27,7 @@
 
 #include <fcntl.h>
 #include <openssl/err.h>
+#include <openssl/evp.h>
 
 #include "check_ssl.h"
 #include "check_api.h"
@@ -315,8 +316,19 @@ ssl_read_thread(thread_ref_t thread)
 	} else if (req->error) {
 
 		/* All the SSL streal has been parsed */
-		if (url->digest)
-			MD5_Final(digest, &req->context);
+		if (url->digest) {
+			if (req->context) {
+				if (EVP_DigestFinal_ex(req->context, digest, NULL) != 1) {
+					log_message(LOG_INFO, "SSL digest finalization failed");
+					/* digest is now indeterminate: force a mismatch */
+					memset(digest, 0, MD5_DIGEST_LENGTH);
+				}
+				EVP_MD_CTX_free(req->context);
+				req->context = NULL;
+			} else
+				/* digest could not be computed: force a mismatch */
+				memset(digest, 0, MD5_DIGEST_LENGTH);
+		}
 		SSL_set_quiet_shutdown(req->ssl, 1);
 
 		r = (req->error == SSL_ERROR_ZERO_RETURN) ? SSL_shutdown(req->ssl) : 0;

--- a/tools/keepalived/keepalived/include/check_http.h
+++ b/tools/keepalived/keepalived/include/check_http.h
@@ -27,7 +27,8 @@
 /* system includes */
 #include <sys/types.h>
 #include <stdbool.h>
-#include <openssl/md5.h>
+#include <openssl/md5.h>	/* for MD5_DIGEST_LENGTH (not deprecated) */
+#include <openssl/evp.h>
 #include <openssl/ssl.h>
 #ifdef _WITH_REGEX_CHECK_
 #define PCRE2_CODE_UNIT_WIDTH 8
@@ -63,7 +64,7 @@ typedef struct _request {
 	size_t				len;
 	SSL				*ssl;
 	BIO				*bio;
-	MD5_CTX				context;
+	EVP_MD_CTX			*context;
 	size_t				content_len;
 	size_t				rx_bytes;
 #ifdef _WITH_REGEX_CHECK_

--- a/tools/keepalived/keepalived/include/vrrp_ipsecah.h
+++ b/tools/keepalived/keepalived/include/vrrp_ipsecah.h
@@ -51,6 +51,6 @@ typedef struct _seq_counter {
 	uint32_t		seq_number;
 } seq_counter_t;
 
-extern void hmac_md5(const unsigned char *, size_t, const unsigned char *, size_t, const unsigned char *, size_t, unsigned char *);
+extern int hmac_md5(const unsigned char *, size_t, const unsigned char *, size_t, const unsigned char *, size_t, unsigned char *);
 
 #endif

--- a/tools/keepalived/keepalived/vrrp/vrrp.c
+++ b/tools/keepalived/keepalived/vrrp/vrrp.c
@@ -511,8 +511,11 @@ vrrp_update_pkt(vrrp_t *vrrp, uint8_t prio, struct sockaddr_storage* addr)
 				   -- rfc2402.3.3.3.1.1.1 & rfc2401.5
 				 */
 				memset(&ah->auth_data, 0, sizeof(ah->auth_data));
-				hmac_md5((const unsigned char *)&iph, sizeof iph, (const unsigned char *)ah, vrrp->send_buffer_size - sizeof (struct iphdr), vrrp->auth_data, sizeof (vrrp->auth_data), digest);
-				memcpy(ah->auth_data, digest, HMAC_MD5_TRUNC);
+				if (hmac_md5((const unsigned char *)&iph, sizeof iph, (const unsigned char *)ah, vrrp->send_buffer_size - sizeof (struct iphdr), vrrp->auth_data, sizeof (vrrp->auth_data), digest) == 0)
+					memcpy(ah->auth_data, digest, HMAC_MD5_TRUNC);
+				else
+					/* leave auth_data zeroed: peers reject the unauthenticated advert */
+					log_message(LOG_INFO, "(%s) IPSEC-AH : HMAC-MD5 computation failed on send", vrrp->iname);
 			}
 		}
 #endif
@@ -577,9 +580,15 @@ vrrp_in_chk_ipsecah(vrrp_t *vrrp, const struct iphdr *ip, const ipsec_ah_t *ah, 
 	memset(digest, 0, MD5_DIGEST_LENGTH);
 
 	/* Compute the ICV */
-	hmac_md5((const unsigned char *)ip_tmp, hdr_len,
+	if (hmac_md5((const unsigned char *)ip_tmp, hdr_len,
 		 (const unsigned char *)hd, buflen - ((const unsigned char *)hd - (const unsigned char *)ip)
-		 , vrrp->auth_data, sizeof (vrrp->auth_data) , digest);
+		 , vrrp->auth_data, sizeof (vrrp->auth_data) , digest) != 0) {
+		/* digest computation failed: fail closed, never compare a zeroed
+		 * digest (an all-zero ICV would otherwise falsely authenticate) */
+		log_message(LOG_INFO, "(%s) IPSEC-AH : HMAC-MD5 computation failed,"
+				      " dropping packet", vrrp->iname);
+		return true;
+	}
 
 	if (memcmp_constant_time(ah->auth_data, digest, HMAC_MD5_TRUNC) != 0) {
 		log_message(LOG_INFO, "(%s) IPSEC-AH : invalid"
@@ -1245,8 +1254,13 @@ vrrp_build_ipsecah(vrrp_t * vrrp, char *buffer, size_t buflen)
 	   => No padding needed.
 	   -- rfc2402.3.3.3.1.1.1 & rfc2401.5
 	 */
-	hmac_md5((unsigned char *) buffer, buflen, NULL, 0, vrrp->auth_data, sizeof (vrrp->auth_data), digest);
-	memcpy(ah->auth_data, digest, HMAC_MD5_TRUNC);
+	if (hmac_md5((unsigned char *) buffer, buflen, NULL, 0, vrrp->auth_data, sizeof (vrrp->auth_data), digest) == 0)
+		memcpy(ah->auth_data, digest, HMAC_MD5_TRUNC);
+	else {
+		/* fail closed: zero ICV so peers reject the unauthenticated advert */
+		memset(ah->auth_data, 0, HMAC_MD5_TRUNC);
+		log_message(LOG_INFO, "(%s) IPSEC-AH : HMAC-MD5 computation failed while building packet", vrrp->iname);
+	}
 }
 #endif
 

--- a/tools/keepalived/keepalived/vrrp/vrrp_ipsecah.c
+++ b/tools/keepalived/keepalived/vrrp/vrrp_ipsecah.c
@@ -24,19 +24,26 @@
 
 #include "config.h"
 
-#include <openssl/md5.h>
+#include <openssl/evp.h>
+#include <openssl/md5.h>	/* for MD5_DIGEST_LENGTH (not deprecated) */
 #include <string.h>
 
 #include "vrrp_ipsecah.h"
+#include "logger.h"
 
 #define	BLOCK_SIZE	64
 
-/* hmac_md5 computation according to the RFCs 2085 & 2104 */
-void
+/* hmac_md5 computation according to the RFCs 2085 & 2104.
+ *
+ * OpenSSL 3.0 deprecates the one-shot MD5_Init/Update/Final API, so this uses
+ * the EVP digest API instead. Returns 0 on success, -1 on failure. On failure
+ * the digest is zeroed so the caller cannot accidentally authenticate with a
+ * stale/partial value (the receive path compares the digest byte-for-byte). */
+int
 hmac_md5(const unsigned char *buffer1, size_t buffer1_len, const unsigned char *buffer2, size_t buffer2_len,
 	 const unsigned char *key, size_t key_len, unsigned char *digest)
 {
-	MD5_CTX context;
+	EVP_MD_CTX *context;
 	unsigned char k_ipad[BLOCK_SIZE+1];	/* inner padding - key XORd with ipad */
 	unsigned char k_opad[BLOCK_SIZE+1];	/* outer padding - key XORd with opad */
 	unsigned char tk[MD5_DIGEST_LENGTH];
@@ -47,14 +54,17 @@ hmac_md5(const unsigned char *buffer1, size_t buffer1_len, const unsigned char *
 	memset(k_opad, 0, sizeof (k_opad));
 	memset(tk, 0, sizeof (tk));
 
+	context = EVP_MD_CTX_new();
+	if (context == NULL)
+		goto err;
+
 	/* If the key is longer than 64 bytes => set it to key=MD5(key) */
 	if (key_len > BLOCK_SIZE) {
-		MD5_CTX tctx;
-
 		/* Compute the MD5 digest */
-		MD5_Init(&tctx);
-		MD5_Update(&tctx, key, key_len);
-		MD5_Final(tk, &tctx);
+		if (EVP_DigestInit_ex(context, EVP_md5(), NULL) != 1 ||
+		    EVP_DigestUpdate(context, key, key_len) != 1 ||
+		    EVP_DigestFinal_ex(context, tk, NULL) != 1)
+			goto err;
 
 		key = tk;
 		key_len = MD5_DIGEST_LENGTH;
@@ -79,16 +89,30 @@ hmac_md5(const unsigned char *buffer1, size_t buffer1_len, const unsigned char *
 	}
 
 	/* Compute inner MD5 */
-	MD5_Init(&context);				/* Init context for 1st pass */
-	MD5_Update(&context, k_ipad, BLOCK_SIZE);	/* start with inner pad */
-	MD5_Update(&context, buffer1, buffer1_len);	/* next with buffer datagram */
-	if (buffer2)
-		MD5_Update(&context, buffer2, buffer2_len); /* next with buffer datagram */
-	MD5_Final(digest, &context);			/* Finish 1st pass */
+	if (EVP_DigestInit_ex(context, EVP_md5(), NULL) != 1 ||
+	    EVP_DigestUpdate(context, k_ipad, BLOCK_SIZE) != 1 ||
+	    EVP_DigestUpdate(context, buffer1, buffer1_len) != 1)
+		goto err;
+	if (buffer2 && EVP_DigestUpdate(context, buffer2, buffer2_len) != 1)
+		goto err;
+	if (EVP_DigestFinal_ex(context, digest, NULL) != 1)
+		goto err;
 
 	/* Compute outer MD5 */
-	MD5_Init(&context);				/* Init context for 2nd pass */
-	MD5_Update(&context, k_opad, BLOCK_SIZE);	/* start with inner pad */
-	MD5_Update(&context, digest, MD5_DIGEST_LENGTH); /* next result of 1st pass */
-	MD5_Final(digest, &context);			/* Finish 2nd pass */
+	if (EVP_MD_CTX_reset(context) != 1 ||		/* reuse ctx for 2nd pass (as upstream) */
+	    EVP_DigestInit_ex(context, EVP_md5(), NULL) != 1 ||
+	    EVP_DigestUpdate(context, k_opad, BLOCK_SIZE) != 1 ||
+	    EVP_DigestUpdate(context, digest, MD5_DIGEST_LENGTH) != 1 ||
+	    EVP_DigestFinal_ex(context, digest, NULL) != 1)
+		goto err;
+
+	EVP_MD_CTX_free(context);
+	return 0;
+
+err:
+	if (context)
+		EVP_MD_CTX_free(context);
+	memset(digest, 0, MD5_DIGEST_LENGTH);
+	log_message(LOG_INFO, "hmac_md5: EVP MD5 computation failed");
+	return -1;
 }


### PR DESCRIPTION
## 背景

OpenSSL 3.0 弃用了一次性/低层摘要接口(`MD5()`、`SHA1()`、`SHA512()` 及 `MD5_*`/`SHA1_*` 的 `Init/Update/Final` 与 `*_CTX`)。本 PR 把全树仍在使用这些接口的地方迁移到 EVP,使代码在 OpenSSL ≥3.0(含 `no-deprecated` 构建)下干净编译。

## 改动

**数据面 / 核心(DPVS)**
- `ip_vs_synproxy.c`:SYN cookie 哈希改用 in-tree `md5_transform()`(每 SYN 热路径,无堆分配、无 EVP 上下文开销)。
- `ip_vs_proto_tcp.c`:TCP 安全序列号 `SHA1()` → `EVP_Digest(EVP_sha1)`。
- `inetaddr.c`:稳定 IPv6 地址生成 `SHA512()` → `EVP_Digest(EVP_sha512)`,并修复一处既有的摘要缓冲越界。

**keepalived**
- `vrrp_ipsecah.c` `hmac_md5()`:改用 EVP,并增加失败处理。
- `check_http.c` / `check_ssl.c` / `check_http.h`:`MD5_CTX` → `EVP_MD_CTX *`,补齐判空、返回值检查与各路径释放。
- `genhash`:`hash_context_t` 改持 `EVP_MD_CTX *`,函数指针表后加 EVP 适配封装(MD5/SHA1),并在错误路径释放上下文。
- `configure.ac`:探测改为非弃用符号 `EVP_DigestInit_ex` / `EVP_sha1`。

**不在范围**:`libconhash` 自带 MD5(不依赖 OpenSSL)与 `include/md5.h`(in-tree transform)保持不动。
