### PR TITLE
keepalived: correct inverted kill return check in MISC_CHECK

### DIFF
--- a/tools/keepalived/keepalived/check/check_misc.c
+++ b/tools/keepalived/keepalived/check/check_misc.c
@@ -337,7 +337,7 @@ misc_check_child_thread(thread_ref_t thread)
 		if (timeout) {
 			/* If kill returns an error, we can't kill the process since either the process has terminated,
 			 * or we don't have permission. If we can't kill it, there is no point trying again. */
-			if (!kill(-pid, sig_num)) {
+			if (kill(-pid, sig_num)) {
 				if (errno == ESRCH) {
 					/* The process does not exist, and we should
 					 * have reaped its exit status, otherwise it


### PR DESCRIPTION
The existing logic incorrectly interpreted the non-zero return value
(failure) as success, leading to an inverted decision in the MISC_CHECK
process. This commit corrects the check to properly identify kill
failures.

Reference: https://github.com/acassen/keepalived/commit/2738ee60