### PR TITLE
fix build error in ubuntu2204

### DIFF
--- a/tools/dpip/lldp.c
+++ b/tools/dpip/lldp.c
@@ -98,7 +98,7 @@ static int lldp_do_cmd(struct dpip_obj *obj, dpip_cmd_t cmd, struct dpip_conf *c
             printf("-*-*-*- %s LLDP Message on Port %s -*-*-*-\n",
                     message->param.node == DPVS_LLDP_NODE_NEIGH ? "Neighbour" : "Local",
                     message->param.ifname);
-            printf(message->message);
+            printf("-*-*-*- LLDP Message: %s -*-*-*-\n", message->message);
             dpvs_sockopt_msg_free(message);
             return EDPVS_OK;
         default:


### PR DESCRIPTION
fix build error :
`make[2]: Entering directory '/home/ubuntu/dpvs/tools/dpip'
cc -g -O0 -Wall -Werror -Wstrict-prototypes -Wmissing-prototypes -Wno-address-of-packed-member -I ../../include -I ../keepalived/keepalived/include -D DPVS_MAX_LCORE=64 -D DPIP_VERSION=\"1.10-2\"   -c -o lldp.o lldp.c
lldp.c: In function ‘lldp_do_cmd’:
lldp.c:101:27: error: format not a string literal and no format arguments [-Werror=format-security]
  101 |             printf(message->message);
      |                    ~~~~~~~^~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [<builtin>: lldp.o] Error 1
make[2]: Leaving directory '/home/ubuntu/dpvs/tools/dpip'
make[1]: *** [Makefile:29: all] Error 1
make[1]: Leaving directory '/home/ubuntu/dpvs/tools'
`