### PR TITLE
ipvs: only set RTE_MBUF_F_TX_IP_CKSUM when IP csum offload is enabled

### DIFF
--- a/src/ipvs/ip_vs_proto_tcp.c
+++ b/src/ipvs/ip_vs_proto_tcp.c
@@ -196,7 +196,10 @@ int tcp_send_csum(int af, int iphdrlen, struct tcphdr *th,
         if (likely(select_dev && (select_dev->flag & NETIF_PORT_FLAG_TX_TCP_CSUM_OFFLOAD))) {
             mbuf->l3_len = iphdrlen;
             mbuf->l4_len = (th->doff << 2);
-            mbuf->ol_flags |= (RTE_MBUF_F_TX_TCP_CKSUM | RTE_MBUF_F_TX_IP_CKSUM | RTE_MBUF_F_TX_IPV4);
+            mbuf->ol_flags |= (RTE_MBUF_F_TX_TCP_CKSUM | RTE_MBUF_F_TX_IPV4);
+            if (select_dev->flag & NETIF_PORT_FLAG_TX_IP_CSUM_OFFLOAD) {
+                mbuf->ol_flags |= RTE_MBUF_F_TX_IP_CKSUM;
+            }
             th->check = rte_ipv4_phdr_cksum(iph, mbuf->ol_flags);
         } else {
             if (mbuf_may_pull(mbuf, mbuf->pkt_len) != 0)

--- a/src/ipvs/ip_vs_proto_udp.c
+++ b/src/ipvs/ip_vs_proto_udp.c
@@ -138,7 +138,10 @@ int udp_send_csum(int af, int iphdrlen, struct rte_udp_hdr *uh,
             if (likely(select_dev && (select_dev->flag & NETIF_PORT_FLAG_TX_UDP_CSUM_OFFLOAD))) {
                 mbuf->l3_len = iphdrlen;
                 mbuf->l4_len = sizeof(struct rte_udp_hdr);
-                mbuf->ol_flags |= (RTE_MBUF_F_TX_UDP_CKSUM | RTE_MBUF_F_TX_IP_CKSUM | RTE_MBUF_F_TX_IPV4);
+                mbuf->ol_flags |= (RTE_MBUF_F_TX_UDP_CKSUM | RTE_MBUF_F_TX_IPV4);
+                if (select_dev->flag & NETIF_PORT_FLAG_TX_IP_CSUM_OFFLOAD) {
+                    mbuf->ol_flags |= RTE_MBUF_F_TX_IP_CKSUM;
+                }
                 uh->dgram_cksum = rte_ipv4_phdr_cksum(iph, mbuf->ol_flags);
             } else {
                 if (mbuf_may_pull(mbuf, mbuf->pkt_len) != 0)


### PR DESCRIPTION
使用vmnet3网卡时，默认网卡属性如下：

`root@liningjie:/home/ubuntu/dpvs# ./bin/dpip link show
1: dpdk0: socket 0 mtu 1500 rx-queue 1 tx-queue 1
    UP 10000 Mbps full-duplex fixed-nego allmulticast lldp
    addr 00:0C:29:FA:06:B7 OF_TX_TCP_CSUM OF_TX_UDP_CSUM OF_TX_FAST_FREE
`
所以在tcp发送报文时，tcp_send_csum函数在如下代码行强制加上RTE_MBUF_F_TX_IP_CKSUM 属性会导致发送的报文IP CHECKSUM为0，测试环境为VMNET3网卡