### PR TITLE
uoa: fix build on kernels that renamed from_timer() to timer_container_of()

### DIFF
--- a/kmod/uoa/uoa.c
+++ b/kmod/uoa/uoa.c
@@ -59,6 +59,16 @@
 #define HAVE_PROC_OPS
 #endif
 
+/*
+ * Upstream v6.16 renamed from_timer() to timer_container_of(). RHEL/AlmaLinux
+ * backport this into 5.14.0-based kernels, so a LINUX_VERSION_CODE check is
+ * unreliable; detect by macro presence instead.
+ */
+#if !defined(from_timer) && defined(timer_container_of)
+#define from_timer(var, callback_timer, timer_fieldname) \
+    timer_container_of(var, callback_timer, timer_fieldname)
+#endif
+
 #define UOA_NEED_EXTRA
 #include "uoa_extra.h"
 #include "uoa.h"


### PR DESCRIPTION
## Problem

Building the `uoa` kernel module on AlmaLinux 9.8 (kernel `5.14.0-687`) fails:

```
uoa.c:498:26: error: implicit declaration of function 'from_timer'; did you mean 'mod_timer'? [-Werror=implicit-function-declaration]
  498 |     struct uoa_map *um = from_timer(um, timer, timer);
```

Upstream commit (Linux v6.16) renamed the `from_timer()` macro to `timer_container_of()`. RHEL/AlmaLinux backport this rename into their `5.14.0`-based kernels, so the kernel version number stays at `5.14` while `from_timer()` is already gone. A `LINUX_VERSION_CODE` based guard cannot detect this case reliably — a `>= KERNEL_VERSION(6,16,0)` check would miss the backported `5.14.0-687`, which is exactly what triggers the build failure.

## Fix

Detect the API by macro presence instead of kernel version, and alias `from_timer()` to `timer_container_of()` only when the new name exists and the old one does not:

```c
#if !defined(from_timer) && defined(timer_container_of)
#define from_timer(var, callback_timer, timer_fieldname) \
    timer_container_of(var, callback_timer, timer_fieldname)
#endif
```

The shim is placed right after `#include <linux/timer.h>`, so the timer helpers are already visible to the `defined()` checks.

Behavior across kernels:

- **4.15 – 6.15**: `from_timer` is defined natively, the shim is skipped.
- **6.16+ and backported 5.14.0 kernels (e.g. AlmaLinux 9.8)**: `from_timer` is gone, `timer_container_of` exists, the shim maps the old name to the new one.
- **< 4.15**: neither macro exists; the shim is skipped, and the existing `#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)` guard at the use site keeps the legacy `unsigned long` timer-callback path. No effect.

## Testing

Verified to build cleanly on AlmaLinux 9.8 (`5.14.0-687.5.4.el9_8.x86_64`). The change is a compile-time macro shim with no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
